### PR TITLE
[refactor] User 다중 역할을 위해 구조 변경

### DIFF
--- a/src/main/java/com/back/domain/auth/entity/TokenType.java
+++ b/src/main/java/com/back/domain/auth/entity/TokenType.java
@@ -1,7 +1,0 @@
-package com.back.domain.auth.entity;
-
-public enum TokenType {
-    USER,       // 사용자
-    ARTIST,     // 작가
-    ADMIN,      // 관리자
-}

--- a/src/main/java/com/back/domain/auth/entity/UserToken.java
+++ b/src/main/java/com/back/domain/auth/entity/UserToken.java
@@ -1,5 +1,6 @@
 package com.back.domain.auth.entity;
 
+import com.back.domain.user.entity.Role;
 import com.back.domain.user.entity.User;
 import com.back.global.jpa.entity.BaseEntity;
 import jakarta.persistence.*;
@@ -30,17 +31,16 @@ public class UserToken extends BaseEntity {
     private Boolean isActive;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "token_type")
-    private TokenType tokenType;
+    private Role loginRole;
 
     // RefreshToken 생성 메서드
-    public static UserToken createRefreshToken(User user, String refreshToken, LocalDateTime expiresAt, TokenType tokenType) {
+    public static UserToken createRefreshToken(User user, String refreshToken, LocalDateTime expiresAt, Role loginRole) {
         return UserToken.builder()
                 .user(user)
                 .refreshToken(refreshToken)
                 .expiresAt(expiresAt)
                 .isActive(true)
-                .tokenType(tokenType)
+                .loginRole(loginRole)
                 .build();
     }
 

--- a/src/main/java/com/back/domain/user/entity/Role.java
+++ b/src/main/java/com/back/domain/user/entity/Role.java
@@ -1,7 +1,30 @@
 package com.back.domain.user.entity;
 
+import java.util.List;
+
 public enum Role {
-    USER,       // 일반 사용자
-    ADMIN,      // 관리자
-    ROOT        // 최고 관리자
+    USER(1),       // 일반 사용자
+    ARTIST(2),     // 작가
+    ADMIN(3),      // 관리자
+    ROOT(4);       // 최고 관리자
+
+    private final int level;
+
+    Role(int level) {
+        this.level = level;
+    }
+
+    public int getLevel() {
+        return level;
+    }
+
+    // 로그인 가능한 역할들 (역할별 정책)
+    public List<Role> getAvailableRoles() {
+        return switch (this) {
+            case USER -> List.of(Role.USER);                               // USER만
+            case ARTIST -> List.of(Role.USER, Role.ARTIST);                // USER, ARTIST
+            case ADMIN -> List.of(Role.ADMIN);                             // ADMIN만
+            case ROOT -> List.of(Role.USER, Role.ARTIST, Role.ADMIN, Role.ROOT); // 모든 권한
+        };
+    }
 }

--- a/src/main/java/com/back/domain/user/entity/User.java
+++ b/src/main/java/com/back/domain/user/entity/User.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @Entity
@@ -78,6 +79,11 @@ public class User extends BaseEntity {
         user.termsAgreedAt = LocalDateTime.now();  // 현재 시간
         user.agreementIp = agreementIp;    // 외부에서 받음
         return user;
+    }
+
+    // 로그인 가능한 역할 목록 반환
+    public List<Role> getAvailableLoginRoles() {
+        return role.getAvailableRoles();
     }
 
     // TODO: 정적 팩토리 메서드 - 소셜 로그인 구현

--- a/src/main/java/com/back/global/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/back/global/security/jwt/JwtTokenProvider.java
@@ -1,11 +1,11 @@
 package com.back.global.security.jwt;
 
-import com.back.domain.auth.entity.TokenType;
+import com.back.domain.user.entity.Role;
 import com.back.global.exception.ServiceException;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
-import org.springframework.beans.factory.annotation.Value;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
@@ -32,7 +32,7 @@ public class JwtTokenProvider {
     /**
      * AccessToken 생성
      */
-    public String createAccessToken(Long userId, String email, TokenType role) {
+    public String createAccessToken(Long userId, String email, Role role) {
         Date now = new Date();
         Date expiration = new Date(now.getTime() + accessTokenExpiration);
 
@@ -49,7 +49,7 @@ public class JwtTokenProvider {
     /**
      * RefreshToken 생성
      */
-    public String createRefreshToken(Long userId, TokenType role) {
+    public String createRefreshToken(Long userId, Role role) {
         Date now = new Date();
         Date expiration = new Date(now.getTime() + refreshTokenExpiration);
 
@@ -125,6 +125,20 @@ public class JwtTokenProvider {
                 .build()
                 .parseSignedClaims(token)
                 .getPayload();
+    }
+
+    /**
+     * 토큰에서 역할 추출
+     */
+    public Role getRoleFromToken(String token) {
+        try {
+            Claims claims = parseToken(token);
+            String role = claims.get("role", String.class);
+            return Role.valueOf(role);
+        } catch (Exception e) {
+            log.error("토큰에서 역할 추출 실패: {}", e.getMessage());
+            throw new ServiceException("JWT_INVALID_ROLE", "토큰에서 역할 추출에 실패했습니다.");
+        }
     }
 
 }


### PR DESCRIPTION
## 📢 기능 설명

### 기존 방식
- 사용자가 하나의 고정된 역할을 가졌었음(USER/ADMIN/ROOT)
- 유저토큰 테이블에서 TokenType 파일이 User의 Role과 중복되고 있었음

### 변경후 방식
- 계층적 권한 구조로 변경 (ROOT > ADMIN > ARTIST > USER)
- 다중 역할 로그인 구조
   ARTIST -> USER OR ARTIST 로그인 가능
   ADMIN -> ADMIN만 가능
   ROOT -> 모든 권한으로 로그인 가능 (*선언만 하고 프로젝트에 반영은 어려울듯함)
- 이제 USER테이블의 ROLE을 이용해서 JWT 토큰 발급 때 선택적으로 발급할수있도록 구조가 됐음

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #47 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?
