### PR TITLE
[refactor] 검증 로직을 별도 Controller로 분리

### DIFF
--- a/src/main/java/com/back/domain/auth/controller/ValidationController.java
+++ b/src/main/java/com/back/domain/auth/controller/ValidationController.java
@@ -1,0 +1,60 @@
+package com.back.domain.auth.controller;
+
+import com.back.domain.auth.dto.request.ValidationCheckRequest;
+import com.back.domain.auth.dto.response.ValidationCheckResponse;
+import com.back.domain.auth.service.ValidationService;
+import com.back.global.rsData.RsData;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Duplicate Validation", description = "중복 검증 API")
+@RestController
+@RequestMapping("/api/auth/duplicate")
+@RequiredArgsConstructor
+public class ValidationController {
+
+    private final ValidationService validationService;
+
+    @PostMapping("/email")
+    @Operation(summary = "이메일 중복 검사", description = "이메일 중복 여부를 확인합니다.")
+    public ResponseEntity<RsData<ValidationCheckResponse>> checkEmailDuplicate(
+            @Valid @RequestBody ValidationCheckRequest request
+    ) {
+        ValidationCheckResponse response = validationService.checkEmailDuplication(request.value());
+
+        return ResponseEntity.ok(
+                RsData.of("200", "이메일 중복 검사 완료", response)
+        );
+    }
+
+    @PostMapping("/name")
+    @Operation(summary = "닉네임 중복 검사", description = "닉네임 중복 여부를 확인합니다.")
+    public ResponseEntity<RsData<ValidationCheckResponse>> checkNameDuplicate(
+            @Valid @RequestBody ValidationCheckRequest request
+    ) {
+        ValidationCheckResponse response = validationService.checkNameDuplicate(request.value());
+
+        return ResponseEntity.ok(
+                RsData.of("200", "닉네임 중복 검사 완료", response)
+        );
+    }
+
+    @PostMapping("/phone")
+    @Operation(summary = "전화번호 중복 검사", description = "전화번호 중복 여부를 확인합니다.")
+    public ResponseEntity<RsData<ValidationCheckResponse>> checkPhoneDuplicate(
+            @Valid @RequestBody ValidationCheckRequest request
+    ) {
+        ValidationCheckResponse response = validationService.checkPhoneDuplicate(request.value());
+
+        return ResponseEntity.ok(
+                RsData.of("200", "전화번호 중복 검사 완료", response)
+        );
+    }
+}

--- a/src/main/java/com/back/domain/auth/dto/request/ValidationCheckRequest.java
+++ b/src/main/java/com/back/domain/auth/dto/request/ValidationCheckRequest.java
@@ -1,0 +1,14 @@
+package com.back.domain.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "중복 검사 요청")
+public record ValidationCheckRequest (
+
+        @Schema(description = "검사할 값", example = "test@example.com")
+        @NotBlank(message = "검사할 값은 필수입니다.")
+        String value
+){
+
+}

--- a/src/main/java/com/back/domain/auth/dto/response/ValidationCheckResponse.java
+++ b/src/main/java/com/back/domain/auth/dto/response/ValidationCheckResponse.java
@@ -1,0 +1,33 @@
+package com.back.domain.auth.dto.response;
+
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record ValidationCheckResponse(
+
+        @Schema(description = "검사한 값", example = "test@example.com")
+        String value,
+
+        @Schema(description = "검사한 필드 타입", example = "email")
+        String fieldType,
+
+        @Schema(description = "중복 여부", example = "false")
+        boolean isDuplicate,
+
+        @Schema(description = "검사 결과 메시지", example = "사용 가능한 이메일입니다.")
+        String message,
+
+        @Schema(description = "사용 가능 여부", example = "true")
+        boolean isAvailable
+
+) {
+    public static ValidationCheckResponse of(String value, String fieldType, boolean isDuplicate, String message) {
+        return new ValidationCheckResponse(
+                value,
+                fieldType,
+                isDuplicate,
+                message,
+                !isDuplicate  // 중복이 아니면 사용 가능
+        );
+    }
+}

--- a/src/main/java/com/back/domain/auth/service/AuthService.java
+++ b/src/main/java/com/back/domain/auth/service/AuthService.java
@@ -184,6 +184,7 @@ public class AuthService {
      */
     private void validateSignUpRequest(SignUpRequest request) {
         validateInput(request);
+        // 중복 검증은 이제 ValidationService에서 처리하지만, 일단 회원가입시 최종 검증을 위해 체크
         validateDuplication(request);
     }
 

--- a/src/main/java/com/back/domain/auth/service/ValidationService.java
+++ b/src/main/java/com/back/domain/auth/service/ValidationService.java
@@ -1,0 +1,115 @@
+package com.back.domain.auth.service;
+
+import com.back.domain.auth.dto.response.ValidationCheckResponse;
+import com.back.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ValidationService {
+
+    private final UserRepository userRepository;
+
+    /**
+     * 이메일 중복 검사
+     */
+    public ValidationCheckResponse checkEmailDuplication(String email) {
+        boolean isDuplicate = userRepository.existsByEmail(email);
+
+        log.debug("이메일 중복 검사: email={}, isDuplicate={}", email, isDuplicate);
+
+        return ValidationCheckResponse.of(
+                email,
+                "email",
+                isDuplicate,
+                isDuplicate ? "이미 사용 중인 이메일입니다." : "사용 가능한 이메일입니다."
+        );
+    }
+
+    /**
+     * 닉네임 중복 검사
+     */
+    public ValidationCheckResponse checkNameDuplicate(String name) {
+        boolean isDuplicate = userRepository.existsByName(name);
+
+        log.debug("닉네임 중복 검사: name={}, isDuplicate={}", name, isDuplicate);
+
+        return ValidationCheckResponse.of(
+                name,
+                "name",
+                isDuplicate,
+                isDuplicate ? "이미 사용 중인 닉네임입니다." : "사용 가능한 닉네임입니다."
+        );
+    }
+
+
+    /**
+     * 전화번호 중복 검사
+     */
+    public ValidationCheckResponse checkPhoneDuplicate(String phone) {
+        boolean isDuplicate = userRepository.existsByPhone(phone);
+
+        log.debug("전화번호 중복 검사: phone={}, isDuplicate={}", phone, isDuplicate);
+
+        return ValidationCheckResponse.of(
+                phone,
+                "phone",
+                isDuplicate,
+                isDuplicate ? "이미 사용 중인 전화번호입니다." : "사용 가능한 전화번호입니다."
+        );
+    }
+
+
+    /**
+     * 특정 사용자 ID를 제외한 중복 검사 (회원정보 수정시 사용)
+     * 필요시 주석 해제 후 사용
+     */
+    /*
+    public ValidationCheckResponse checkEmailDuplicateExcludingUserId(String email, Long excludeUserId) {
+        boolean isDuplicate = userRepository.existsByEmailAndIdNot(email, excludeUserId);
+
+        log.debug("이메일 중복 검사 (사용자 제외): email={}, excludeUserId={}, isDuplicate={}",
+                email, excludeUserId, isDuplicate);
+
+        return ValidationCheckResponse.of(
+                email,
+                "email",
+                isDuplicate,
+                isDuplicate ? "이미 사용 중인 이메일입니다." : "사용 가능한 이메일입니다."
+        );
+    }
+
+    public ValidationCheckResponse checkNameDuplicateExcludingUserId(String name, Long excludeUserId) {
+        boolean isDuplicate = userRepository.existsByNameAndIdNot(name, excludeUserId);
+
+        log.debug("닉네임 중복 검사 (사용자 제외): name={}, excludeUserId={}, isDuplicate={}",
+                name, excludeUserId, isDuplicate);
+
+        return ValidationCheckResponse.of(
+                name,
+                "name",
+                isDuplicate,
+                isDuplicate ? "이미 사용 중인 닉네임입니다." : "사용 가능한 닉네임입니다."
+        );
+    }
+
+    public ValidationCheckResponse checkPhoneDuplicateExcludingUserId(String phone, Long excludeUserId) {
+        boolean isDuplicate = userRepository.existsByPhoneAndIdNot(phone, excludeUserId);
+
+        log.debug("전화번호 중복 검사 (사용자 제외): phone={}, excludeUserId={}, isDuplicate={}",
+                phone, excludeUserId, isDuplicate);
+
+        return ValidationCheckResponse.of(
+                phone,
+                "phone",
+                isDuplicate,
+                isDuplicate ? "이미 사용 중인 전화번호입니다." : "사용 가능한 전화번호입니다."
+        );
+    }
+    */
+}

--- a/src/main/java/com/back/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/back/domain/user/repository/UserRepository.java
@@ -13,4 +13,12 @@ public interface UserRepository extends JpaRepository<User, Long>{
     boolean existsByEmail(String email);
     boolean existsByName(String name);
     boolean existsByPhone(String phone);
+
+
+    // 중복 체크용 (회원정보 수정시 - 본인 제외)
+    /* 필요시 주석 해제
+    boolean existsByEmailAndIdNot(String email, Long id);
+    boolean existsByNameAndIdNot(String name, Long id);
+    boolean existsByPhoneAndIdNot(String phone, Long id);
+    */
 }

--- a/src/test/java/com/back/domain/auth/controller/ValidationControllerTest.java
+++ b/src/test/java/com/back/domain/auth/controller/ValidationControllerTest.java
@@ -1,0 +1,213 @@
+package com.back.domain.auth.controller;
+
+import com.back.domain.auth.dto.request.ValidationCheckRequest;
+import com.back.domain.auth.dto.response.ValidationCheckResponse;
+import com.back.domain.auth.service.ValidationService;
+import com.back.global.rsData.RsData;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ValidationController 단위 테스트")
+class ValidationControllerTest {
+
+    @Mock
+    private ValidationService validationService;
+
+    @InjectMocks
+    private ValidationController validationController;
+
+    @Nested
+    @DisplayName("이메일 중복 검사 테스트")
+    class CheckEmailDuplicateTest {
+
+        @Test
+        @DisplayName("성공 - 사용 가능한 이메일")
+        void checkEmailDuplicate_Available_Success() {
+            // given
+            ValidationCheckRequest request = new ValidationCheckRequest("test@example.com");
+            ValidationCheckResponse mockResponse = ValidationCheckResponse.of(
+                    "test@example.com", "email", false, "사용 가능한 이메일입니다."
+            );
+
+            given(validationService.checkEmailDuplication("test@example.com")).willReturn(mockResponse);
+
+            // when
+            ResponseEntity<RsData<ValidationCheckResponse>> response =
+                    validationController.checkEmailDuplicate(request);
+
+            // then
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(response.getBody().resultCode()).isEqualTo("200");
+            assertThat(response.getBody().msg()).isEqualTo("이메일 중복 검사 완료");
+            assertThat(response.getBody().data().value()).isEqualTo("test@example.com");
+            assertThat(response.getBody().data().fieldType()).isEqualTo("email");
+            assertThat(response.getBody().data().isDuplicate()).isFalse();
+            assertThat(response.getBody().data().isAvailable()).isTrue();
+            assertThat(response.getBody().data().message()).isEqualTo("사용 가능한 이메일입니다.");
+
+            verify(validationService).checkEmailDuplication("test@example.com");
+        }
+
+        @Test
+        @DisplayName("실패 - 이미 사용 중인 이메일")
+        void checkEmailDuplicate_Duplicate_Fail() {
+            // given
+            ValidationCheckRequest request = new ValidationCheckRequest("duplicate@example.com");
+            ValidationCheckResponse mockResponse = ValidationCheckResponse.of(
+                    "duplicate@example.com", "email", true, "이미 사용 중인 이메일입니다."
+            );
+
+            given(validationService.checkEmailDuplication("duplicate@example.com")).willReturn(mockResponse);
+
+            // when
+            ResponseEntity<RsData<ValidationCheckResponse>> response =
+                    validationController.checkEmailDuplicate(request);
+
+            // then
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(response.getBody().resultCode()).isEqualTo("200");
+            assertThat(response.getBody().msg()).isEqualTo("이메일 중복 검사 완료");
+            assertThat(response.getBody().data().value()).isEqualTo("duplicate@example.com");
+            assertThat(response.getBody().data().fieldType()).isEqualTo("email");
+            assertThat(response.getBody().data().isDuplicate()).isTrue();
+            assertThat(response.getBody().data().isAvailable()).isFalse();
+            assertThat(response.getBody().data().message()).isEqualTo("이미 사용 중인 이메일입니다.");
+
+            verify(validationService).checkEmailDuplication("duplicate@example.com");
+        }
+    }
+
+    @Nested
+    @DisplayName("닉네임 중복 검사 테스트")
+    class CheckNameDuplicateTest {
+
+        @Test
+        @DisplayName("성공 - 사용 가능한 닉네임")
+        void checkNameDuplicate_Available_Success() {
+            // given
+            ValidationCheckRequest request = new ValidationCheckRequest("testuser");
+            ValidationCheckResponse mockResponse = ValidationCheckResponse.of(
+                    "testuser", "name", false, "사용 가능한 닉네임입니다."
+            );
+
+            given(validationService.checkNameDuplicate("testuser")).willReturn(mockResponse);
+
+            // when
+            ResponseEntity<RsData<ValidationCheckResponse>> response =
+                    validationController.checkNameDuplicate(request);
+
+            // then
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(response.getBody().resultCode()).isEqualTo("200");
+            assertThat(response.getBody().msg()).isEqualTo("닉네임 중복 검사 완료");
+            assertThat(response.getBody().data().value()).isEqualTo("testuser");
+            assertThat(response.getBody().data().fieldType()).isEqualTo("name");
+            assertThat(response.getBody().data().isDuplicate()).isFalse();
+            assertThat(response.getBody().data().isAvailable()).isTrue();
+            assertThat(response.getBody().data().message()).isEqualTo("사용 가능한 닉네임입니다.");
+
+            verify(validationService).checkNameDuplicate("testuser");
+        }
+
+        @Test
+        @DisplayName("실패 - 이미 사용 중인 닉네임")
+        void checkNameDuplicate_Duplicate_Fail() {
+            // given
+            ValidationCheckRequest request = new ValidationCheckRequest("duplicateuser");
+            ValidationCheckResponse mockResponse = ValidationCheckResponse.of(
+                    "duplicateuser", "name", true, "이미 사용 중인 닉네임입니다."
+            );
+
+            given(validationService.checkNameDuplicate("duplicateuser")).willReturn(mockResponse);
+
+            // when
+            ResponseEntity<RsData<ValidationCheckResponse>> response =
+                    validationController.checkNameDuplicate(request);
+
+            // then
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(response.getBody().resultCode()).isEqualTo("200");
+            assertThat(response.getBody().msg()).isEqualTo("닉네임 중복 검사 완료");
+            assertThat(response.getBody().data().value()).isEqualTo("duplicateuser");
+            assertThat(response.getBody().data().fieldType()).isEqualTo("name");
+            assertThat(response.getBody().data().isDuplicate()).isTrue();
+            assertThat(response.getBody().data().isAvailable()).isFalse();
+            assertThat(response.getBody().data().message()).isEqualTo("이미 사용 중인 닉네임입니다.");
+
+            verify(validationService).checkNameDuplicate("duplicateuser");
+        }
+    }
+
+    @Nested
+    @DisplayName("전화번호 중복 검사 테스트")
+    class CheckPhoneDuplicateTest {
+
+        @Test
+        @DisplayName("성공 - 사용 가능한 전화번호")
+        void checkPhoneDuplicate_Available_Success() {
+            // given
+            ValidationCheckRequest request = new ValidationCheckRequest("01012345678");
+            ValidationCheckResponse mockResponse = ValidationCheckResponse.of(
+                    "01012345678", "phone", false, "사용 가능한 전화번호입니다."
+            );
+
+            given(validationService.checkPhoneDuplicate("01012345678")).willReturn(mockResponse);
+
+            // when
+            ResponseEntity<RsData<ValidationCheckResponse>> response =
+                    validationController.checkPhoneDuplicate(request);
+
+            // then
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(response.getBody().resultCode()).isEqualTo("200");
+            assertThat(response.getBody().msg()).isEqualTo("전화번호 중복 검사 완료");
+            assertThat(response.getBody().data().value()).isEqualTo("01012345678");
+            assertThat(response.getBody().data().fieldType()).isEqualTo("phone");
+            assertThat(response.getBody().data().isDuplicate()).isFalse();
+            assertThat(response.getBody().data().isAvailable()).isTrue();
+            assertThat(response.getBody().data().message()).isEqualTo("사용 가능한 전화번호입니다.");
+
+            verify(validationService).checkPhoneDuplicate("01012345678");
+        }
+
+        @Test
+        @DisplayName("실패 - 이미 사용 중인 전화번호")
+        void checkPhoneDuplicate_Duplicate_Fail() {
+            // given
+            ValidationCheckRequest request = new ValidationCheckRequest("01087654321");
+            ValidationCheckResponse mockResponse = ValidationCheckResponse.of(
+                    "01087654321", "phone", true, "이미 사용 중인 전화번호입니다."
+            );
+
+            given(validationService.checkPhoneDuplicate("01087654321")).willReturn(mockResponse);
+
+            // when
+            ResponseEntity<RsData<ValidationCheckResponse>> response =
+                    validationController.checkPhoneDuplicate(request);
+
+            // then
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(response.getBody().resultCode()).isEqualTo("200");
+            assertThat(response.getBody().msg()).isEqualTo("전화번호 중복 검사 완료");
+            assertThat(response.getBody().data().value()).isEqualTo("01087654321");
+            assertThat(response.getBody().data().fieldType()).isEqualTo("phone");
+            assertThat(response.getBody().data().isDuplicate()).isTrue();
+            assertThat(response.getBody().data().isAvailable()).isFalse();
+            assertThat(response.getBody().data().message()).isEqualTo("이미 사용 중인 전화번호입니다.");
+
+            verify(validationService).checkPhoneDuplicate("01087654321");
+        }
+    }
+}

--- a/src/test/java/com/back/domain/auth/service/ValidationServiceTest.java
+++ b/src/test/java/com/back/domain/auth/service/ValidationServiceTest.java
@@ -1,0 +1,162 @@
+package com.back.domain.auth.service;
+
+
+import com.back.domain.auth.dto.response.ValidationCheckResponse;
+import com.back.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ValidationService 테스트")
+class ValidationServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private ValidationService validationService;
+
+    @Nested
+    @DisplayName("이메일 중복 검사")
+    class CheckEmailDuplication {
+
+        @Test
+        @DisplayName("성공 - 사용 가능한 이메일")
+        void checkEmailDuplication_Available_Success() {
+            // given
+            String email = "test@example.com";
+            given(userRepository.existsByEmail(email)).willReturn(false);
+
+            // when
+            ValidationCheckResponse response = validationService.checkEmailDuplication(email);
+
+            // then
+            assertThat(response.value()).isEqualTo(email);
+            assertThat(response.fieldType()).isEqualTo("email");
+            assertThat(response.isDuplicate()).isFalse();
+            assertThat(response.isAvailable()).isTrue();
+            assertThat(response.message()).isEqualTo("사용 가능한 이메일입니다.");
+
+            verify(userRepository).existsByEmail(email);
+        }
+
+        @Test
+        @DisplayName("실패 - 이미 사용 중인 이메일")
+        void checkEmailDuplication_Duplicate_Fail() {
+            // given
+            String email = "duplicate@example.com";
+            given(userRepository.existsByEmail(email)).willReturn(true);
+
+            // when
+            ValidationCheckResponse response = validationService.checkEmailDuplication(email);
+
+            // then
+            assertThat(response.value()).isEqualTo(email);
+            assertThat(response.fieldType()).isEqualTo("email");
+            assertThat(response.isDuplicate()).isTrue();
+            assertThat(response.isAvailable()).isFalse();
+            assertThat(response.message()).isEqualTo("이미 사용 중인 이메일입니다.");
+
+            verify(userRepository).existsByEmail(email);
+        }
+    }
+
+    @Nested
+    @DisplayName("닉네임 중복 검사")
+    class CheckNameDuplicate {
+
+        @Test
+        @DisplayName("성공 - 사용 가능한 닉네임")
+        void checkNameDuplicate_Available_Success() {
+            // given
+            String name = "testuser";
+            given(userRepository.existsByName(name)).willReturn(false);
+
+            // when
+            ValidationCheckResponse response = validationService.checkNameDuplicate(name);
+
+            // then
+            assertThat(response.value()).isEqualTo(name);
+            assertThat(response.fieldType()).isEqualTo("name");
+            assertThat(response.isDuplicate()).isFalse();
+            assertThat(response.isAvailable()).isTrue();
+            assertThat(response.message()).isEqualTo("사용 가능한 닉네임입니다.");
+
+            verify(userRepository).existsByName(name);
+        }
+
+        @Test
+        @DisplayName("실패 - 이미 사용 중인 닉네임")
+        void checkNameDuplicate_Duplicate_Fail() {
+            // given
+            String name = "duplicateuser";
+            given(userRepository.existsByName(name)).willReturn(true);
+
+            // when
+            ValidationCheckResponse response = validationService.checkNameDuplicate(name);
+
+            // then
+            assertThat(response.value()).isEqualTo(name);
+            assertThat(response.fieldType()).isEqualTo("name");
+            assertThat(response.isDuplicate()).isTrue();
+            assertThat(response.isAvailable()).isFalse();
+            assertThat(response.message()).isEqualTo("이미 사용 중인 닉네임입니다.");
+
+            verify(userRepository).existsByName(name);
+        }
+    }
+
+    @Nested
+    @DisplayName("전화번호 중복 검사")
+    class CheckPhoneDuplicate {
+
+        @Test
+        @DisplayName("성공 - 사용 가능한 전화번호")
+        void checkPhoneDuplicate_Available_Success() {
+            // given
+            String phone = "01012345678";
+            given(userRepository.existsByPhone(phone)).willReturn(false);
+
+            // when
+            ValidationCheckResponse response = validationService.checkPhoneDuplicate(phone);
+
+            // then
+            assertThat(response.value()).isEqualTo(phone);
+            assertThat(response.fieldType()).isEqualTo("phone");
+            assertThat(response.isDuplicate()).isFalse();
+            assertThat(response.isAvailable()).isTrue();
+            assertThat(response.message()).isEqualTo("사용 가능한 전화번호입니다.");
+
+            verify(userRepository).existsByPhone(phone);
+        }
+
+        @Test
+        @DisplayName("실패 - 이미 사용 중인 전화번호")
+        void checkPhoneDuplicate_Duplicate_Fail() {
+            // given
+            String phone = "01087654321";
+            given(userRepository.existsByPhone(phone)).willReturn(true);
+
+            // when
+            ValidationCheckResponse response = validationService.checkPhoneDuplicate(phone);
+
+            // then
+            assertThat(response.value()).isEqualTo(phone);
+            assertThat(response.fieldType()).isEqualTo("phone");
+            assertThat(response.isDuplicate()).isTrue();
+            assertThat(response.isAvailable()).isFalse();
+            assertThat(response.message()).isEqualTo("이미 사용 중인 전화번호입니다.");
+
+            verify(userRepository).existsByPhone(phone);
+        }
+    }
+}

--- a/src/test/java/com/back/domain/dashboard/customer/controller/DashboardControllerTest.java
+++ b/src/test/java/com/back/domain/dashboard/customer/controller/DashboardControllerTest.java
@@ -82,7 +82,7 @@ class DashboardControllerTest {
                         .param("status", "PENDING"))
                 .andDo(print())
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.resultCode").value("200-OK"))
+                .andExpect(jsonPath("$.resultCode").value("200"))
                 .andExpect(jsonPath("$.data.summary.total").value(2))
                 .andExpect(jsonPath("$.data.content").isArray())
                 .andExpect(jsonPath("$.data.content[0].applicationId").value(1))


### PR DESCRIPTION
## 📢 기능 설명

###회원가입 시 중복검증을 할 때, API를 따로 빼서 사용하기 위한 리팩토링 작업

### 검증 로직 별도 분리
- ValidationController 생성
- ValidationRequest/Response DTO 생성
- ValidationService 생성
- ValidationService/Controller 테스트코드 생성

### 기존 코드에서 사용하는 로직을 재사용해서 AI가 99% 만든 코드입니다


## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #90 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?
