### PR TITLE
[fix] OAuth2 로그인 예외처리 및 방식 수정

### DIFF
--- a/src/main/java/com/back/domain/user/entity/User.java
+++ b/src/main/java/com/back/domain/user/entity/User.java
@@ -15,7 +15,7 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User extends BaseEntity {
 
-    @Column(unique = true, nullable = false)
+    @Column(unique = true, nullable = true) // OAuth Kakao 사용자를 위해 nullable 허용
     private String email;
 
     @Column(nullable = true) // OAuth 사용자를 위해 nullable 허용
@@ -24,7 +24,7 @@ public class User extends BaseEntity {
     @Column(unique = true, nullable = false)
     private String name;
 
-    @Column(unique = true, nullable = false)
+    @Column(unique = true, nullable = true) // OAuth 사용자를 위해 nullable 허용
     private String phone;
 
     private String profileImageUrl;
@@ -72,6 +72,7 @@ public class User extends BaseEntity {
         user.provider = Provider.LOCAL;
         user.money = 0;
         user.point = 0;
+        user.isArtistVerified = false;
         user.privacyRequiredAgreed = true;  // 회원가입 시 필수 동의
         user.marketingAgreed = false;       // 선택 동의 (기본값)
         user.termsAgreedAt = LocalDateTime.now();  // 현재 시간
@@ -172,7 +173,10 @@ public class User extends BaseEntity {
     public static User createOAuthUser(String email, String name, Provider provider, String providerId) {
         User user = new User();
         user.email = email;
-        user.name = name;
+
+        // Provider를 포함한 고유한 이름 생성 (예: "홍길동_GOOGLE")
+        user.name = name + "_" + provider.name();
+
         user.provider = provider;
         user.providerId = providerId;
         user.password = null;  // 소셜 로그인은 비밀번호 없음
@@ -195,9 +199,6 @@ public class User extends BaseEntity {
 
     // OAuth 프로필 정보 업데이트 (재로그인 시)
     public void updateOAuthProfile(String name, String profileImageUrl) {
-        if (name != null && !name.isBlank()) {
-            this.name = name;
-        }
         if (profileImageUrl != null && !profileImageUrl.isBlank()) {
             this.profileImageUrl = profileImageUrl;
         }

--- a/src/main/java/com/back/global/security/oauth2/KakaoUserInfo.java
+++ b/src/main/java/com/back/global/security/oauth2/KakaoUserInfo.java
@@ -40,10 +40,14 @@ public class KakaoUserInfo implements OAuth2UserInfo{
     @Override
     public String getEmail() {
         Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
-        if (kakaoAccount == null) {
-            return null;
+
+        // 이메일 제공 동의한 경우
+        if (kakaoAccount != null && kakaoAccount.get("email") != null) {
+            return (String) kakaoAccount.get("email");
         }
-        return (String) kakaoAccount.get("email");
+
+        // 이메일 없으면 더미 이메일 생성
+        return "kakao_" + getProviderId() + "@dummy.local";
     }
 
     @Override

--- a/src/main/java/com/back/global/security/oauth2/OAuth2SuccessHandler.java
+++ b/src/main/java/com/back/global/security/oauth2/OAuth2SuccessHandler.java
@@ -10,6 +10,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
@@ -81,17 +82,28 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
         log.info("JWT 토큰 발급 완료 - userId: {}", user.getId());
 
-        // 4. state 파라미터에서 redirectUrl 추출
+        // 4. 쿠키 생성 (기존 로그인 방식과 동일)
+        ResponseCookie accessTokenCookie = createTokenCookie(
+                "accessToken",
+                accessToken,
+                accessTokenExpiration / 1000
+        );
+
+        ResponseCookie refreshTokenCookie = createTokenCookie(
+                "refreshToken",
+                refreshToken,
+                refreshTokenExpiration / 1000
+        );
+
+        // 5. 쿠키 설정
+        response.addHeader("Set-Cookie", accessTokenCookie.toString());
+        response.addHeader("Set-Cookie", refreshTokenCookie.toString());
+
+        // 6. state 파라미터에서 redirectUrl 추출
         String redirectUrl = extractRedirectUrl(request);
 
-        // 5. 프론트엔드로 리다이렉트 (토큰을 쿼리 파라미터로 전달)
-        String targetUrl = String.format(
-                "%s%s?access_token=%s&refresh_token=%s&login_type=oauth",
-                frontendUrl,
-                redirectUrl,
-                accessToken,
-                refreshToken
-        );
+        // 7. 프론트엔드로 리다이렉트 (쿠키로 토큰 전달, URL에 노출 안됨)
+        String targetUrl = frontendUrl + redirectUrl;
 
         log.info("프론트엔드로 리다이렉트 - targetUrl: {}", targetUrl);
 
@@ -99,9 +111,21 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     }
 
     /**
+     * 쿠키 생성 헬퍼 메서드 (기존 로그인과 동일)
+     */
+    private ResponseCookie createTokenCookie(String name, String value, long maxAgeSeconds) {
+        return ResponseCookie.from(name, value)
+                .httpOnly(true)
+                .secure(false)  // 개발: false, 운영: true
+                .path("/")
+                .maxAge(maxAgeSeconds)
+                .sameSite("Strict")
+                .build();
+    }
+
+    /**
      * state 파라미터에서 redirectUrl 추출
      */
-
     private String extractRedirectUrl(HttpServletRequest request) {
         String stateParam = request.getParameter("state");
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -42,8 +42,8 @@ spring:
             client-authentication-method: client_secret_post
             client-name: Kakao
             scope:
-              - profile_nickname # 닉네임 + 프로필 이미지 모두 받아옴
-              - account_email
+              - profile_nickname
+              - profile_image
           naver:
             client-id: ${NAVER_CLIENT_ID:dummy-naver-id}
             client-secret: ${NAVER_CLIENT_SECRET:dummy-naver-secret}


### PR DESCRIPTION
## 📢 기능 설명

### 1. OAuth2 토큰 전달 방식 변경 (보안개선)
- OAuth@SuccessHandler 수정
   - Jwt 토큰을 기존에 URL 쿼리 파라미터 대신 **HttpOnly Cookie**로 전달
   - 기존 일반 로그인과 동일 로직 사용

### 2. OAuth 사용자 이름 충돌 방지
- 닉네임과 소셜 로그인 시 이름이 같을 경우 unique 버그가 발생 -> Provider 접미사 자동 추가 (ex. 홍길동_GOOGLE)

### 3. nullable = fasle 버그 수정
- 기존에 이메일이 not null이지만, 카카오에서 이메일을 제공 받을수 없어 버그가 발생 -> 더미 이메일 생성 로직 추가
- 기존에 전화번호가 not null이지만, 소셜 로그인시 null값을 받을수 밖에 없어 버그가 발생 -> null 허용

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #126 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?
