### PR TITLE
[feat] 펀딩 상태 변경 구현 및 스케줄러 추가

### DIFF
--- a/src/main/java/com/back/BackApplication.java
+++ b/src/main/java/com/back/BackApplication.java
@@ -2,8 +2,10 @@ package com.back;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class BackApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/back/domain/funding/controller/FundingStatusController.java
+++ b/src/main/java/com/back/domain/funding/controller/FundingStatusController.java
@@ -1,0 +1,75 @@
+package com.back.domain.funding.controller;
+
+import com.back.domain.funding.service.FundingStatusService;
+import com.back.global.rsData.RsData;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Positive;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/fundings")
+@Tag(name = "펀딩 상태", description = "펀딩 상태 관리 API")
+public class FundingStatusController {
+
+    private final FundingStatusService fundingStatusService;
+
+    @PutMapping("/{id}/close")
+    @PreAuthorize("isAuthenticated()")
+    @Operation(summary = "펀딩 종료", description = "펀딩 수동 종료")
+    public ResponseEntity<RsData<?>> closeFunding(
+            @PathVariable @Positive Long id,
+            @AuthenticationPrincipal(expression = "username") String userEmail) {
+        fundingStatusService.closeFunding(id, userEmail);
+        return ResponseEntity.ok(RsData.of("200", "펀딩이 종료되었습니다."));
+    }
+
+    @PutMapping("/{id}/cancel")
+    @PreAuthorize("isAuthenticated()")
+    @Operation(summary = "펀딩 취소", description = "펀딩 취소")
+    public ResponseEntity<RsData<?>> cancelFunding(
+            @PathVariable @Positive Long id,
+            @AuthenticationPrincipal(expression = "username") String userEmail) {
+        fundingStatusService.cancelFunding(id, userEmail);
+        return ResponseEntity.ok(RsData.of("200", "펀딩이 취소되었습니다."));
+    }
+
+    @PutMapping("/{id}/finalize")
+    @PreAuthorize("hasAuthority('ROLE_ADMIN') or hasAuthority('ROLE_ROOT')")
+    @Operation(summary = "단일 펀딩 최종 처리", description = "펀딩 성공/실패 확정 (관리자 전용) ")
+    public ResponseEntity<RsData<?>> finalizeFunding(
+            @PathVariable @Positive Long id) {
+        fundingStatusService.finalizeFunding(id);
+        return ResponseEntity.ok(RsData.of("200", "펀딩이 최종 처리되었습니다."));
+    }
+
+    @PutMapping("/finalize/all")
+    @PreAuthorize("hasAuthority('ROLE_ADMIN') or hasAuthority('ROLE_ROOT')")
+    @Operation(summary = "모든 펀딩 최종 처리", description = "모든 펀딩 성공/실패 확정 (관리자 전용) ")
+    public ResponseEntity<RsData<?>> finalizeAllFundings() {
+        fundingStatusService.finalizeAllClosedFundings();
+        return ResponseEntity.ok(RsData.of("200", "모든 펀딩이 최종 처리되었습니다."));
+    }
+
+    @PutMapping("/process/all")
+    @PreAuthorize("hasAuthority('ROLE_ADMIN') or hasAuthority('ROLE_ROOT')")
+    @Operation(summary = "모든 펀딩 통합 처리",
+            description = "만료된 펀딩을 종료하고, 종료된 펀딩을 최종 처리합니다. (종료 + 최종 처리 한 번에)")
+    public ResponseEntity<RsData<?>> processAllFundings() {
+        var result = fundingStatusService.processAllFundings();
+
+        String message = String.format(
+                "펀딩 통합 처리 완료 - 종료: %d건, 성공: %d건, 실패: %d건",
+                result.closedCount(), result.successCount(), result.failedCount()
+        );
+
+        return ResponseEntity.ok(
+                RsData.of("200", message)
+        );
+    }
+}

--- a/src/main/java/com/back/domain/funding/entity/Funding.java
+++ b/src/main/java/com/back/domain/funding/entity/Funding.java
@@ -14,7 +14,9 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-@Table(name = "fundings")
+@Table(name = "fundings", indexes = {
+        @Index(name = "idx_funding_status_enddate",
+                columnList = "status, end_date")})
 public class Funding extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
@@ -127,5 +129,41 @@ public class Funding extends BaseEntity {
             }
         }
         return f;
+    }
+
+    // 펀딩 상태 관련 메서드
+    public void close() {
+        if (this.status != FundingStatus.OPEN) {
+            throw new IllegalStateException("진행 중인 펀딩만 종료할 수 있습니다.");
+        }
+        this.status = FundingStatus.CLOSED;
+    }
+
+    public void markAsSuccess() {
+        if (this.status != FundingStatus.CLOSED) {
+            throw new IllegalStateException("종료된 펀딩만 성공 처리할 수 있습니다.");
+        }
+        if (this.collectedAmount < this.targetAmount) {
+            throw new IllegalStateException("목표 금액을 달성하지 못했습니다.");
+        }
+        this.status = FundingStatus.SUCCESS;
+    }
+
+    public void markAsFailed() {
+        if (this.status != FundingStatus.CLOSED) {
+            throw new IllegalStateException("종료된 펀딩만 실패 처리할 수 있습니다.");
+        }
+        this.status = FundingStatus.FAILED;
+    }
+
+    public void cancel() {
+        if (this.status == FundingStatus.SUCCESS || this.status == FundingStatus.FAILED) {
+            throw new IllegalStateException("이미 완료된 펀딩은 취소할 수 없습니다.");
+        }
+        this.status = FundingStatus.CANCELED;
+    }
+
+    public boolean isEndDatePassed() {
+        return LocalDateTime.now().isAfter(this.endDate);
     }
 }

--- a/src/main/java/com/back/domain/funding/repository/FundingRepository.java
+++ b/src/main/java/com/back/domain/funding/repository/FundingRepository.java
@@ -4,12 +4,12 @@ import com.back.domain.funding.entity.Funding;
 import com.back.domain.funding.entity.FundingStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.EntityGraph;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
-import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.*;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -70,6 +70,30 @@ public interface FundingRepository extends JpaRepository<Funding, Long>, JpaSpec
             @Param("sort") String sort,
             @Param("order") String order,
             Pageable pageable
+    );
+
+    // 종료일이 지난 펀딩 조회
+    @Query("SELECT COUNT(f) FROM Funding f " +
+            "WHERE f.status = :status AND f.endDate < :now")
+    long countByStatusAndEndDateBefore(
+            @Param("status") FundingStatus status,
+            @Param("now") LocalDateTime now
+    );
+
+    // 만료된 펀딩 일괄 종료
+    @Modifying
+    @Transactional
+    @Query("UPDATE Funding f SET f.status = 'CLOSED' " +
+            "WHERE f.status = 'OPEN' AND f.endDate < :now")
+    int bulkCloseExpiredFundings(@Param("now") LocalDateTime now);
+
+    // 특정 상태의 펀딩 전체 조회
+    List<Funding> findByStatus(FundingStatus status);
+
+    // 종료된 펀딩 조회 (정합성 체크용)
+    List<Funding> findByStatusAndEndDateBefore(
+            FundingStatus status,
+            LocalDateTime endDate
     );
 }
 

--- a/src/main/java/com/back/domain/funding/scheduler/FundingStatusScheduler.java
+++ b/src/main/java/com/back/domain/funding/scheduler/FundingStatusScheduler.java
@@ -1,0 +1,62 @@
+package com.back.domain.funding.scheduler;
+
+import com.back.domain.funding.service.FundingStatusService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class FundingStatusScheduler {
+
+    private final FundingStatusService fundingStatusService;
+
+    // 매시간 정각에 종료일이 지난 펀딩을 CLOSED로 변경
+    @Scheduled(cron = "0 0 * * * *")
+    public void closeExpiredFundings() {
+        long startTime = System.currentTimeMillis();
+
+        int closed = fundingStatusService.closeExpiredFundings();
+
+        long duration = System.currentTimeMillis() - startTime;
+
+        if (closed > 0) {
+            log.info("[스케줄러] 펀딩 자동 종료 완료 - 처리: {}건, 소요: {}ms", closed, duration);
+
+            // 성능 모니터링: 5초 이상 걸리면 경고
+            if (duration > 5000) {
+                log.warn("[성능 경고] 펀딩 종료 처리 시간 초과: {}ms", duration);
+            }
+        }
+    }
+
+    // 매시간 5분에 CLOSED 펀딩을 SUCCESS/FAILED로 최종 처리
+    @Scheduled(cron = "0 5 * * * *")
+    public void finalizeFundings() {
+        long startTime = System.currentTimeMillis();
+
+        FundingStatusService.FinalizeResult result = fundingStatusService.finalizeAllClosedFundings();
+
+        long duration = System.currentTimeMillis() - startTime;
+
+        if (result.totalProcessed() > 0) {
+            log.info("[스케줄러] 펀딩 최종 처리 완료 - 성공 펀딩: {}건, 실패 펀딩: {}건, 오류: {}건, 소요: {}ms",
+                    result.successCount(), result.failedCount(), result.errorCount(), duration);
+        }
+    }
+
+    /**
+     * 매일 새벽 1시에 정합성 체크 (안전장치)
+     * 혹시 놓친 펀딩이 있는지 확인
+     */
+    @Scheduled(cron = "0 0 1 * * *")
+    public void dailyStatusCheck() {
+        int closed = fundingStatusService.checkAndCloseMissedFundings();
+
+        if (closed > 0) {
+            log.warn("[스케줄러] 정합성 체크 - 누락 펀딩 {}건 처리 완료", closed);
+        }
+    }
+}

--- a/src/main/java/com/back/domain/funding/service/FundingStatusService.java
+++ b/src/main/java/com/back/domain/funding/service/FundingStatusService.java
@@ -1,0 +1,248 @@
+package com.back.domain.funding.service;
+
+import com.back.domain.funding.entity.Funding;
+import com.back.domain.funding.entity.FundingStatus;
+import com.back.domain.funding.repository.FundingContributionRepository;
+import com.back.domain.funding.repository.FundingRepository;
+import com.back.global.exception.ServiceException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class FundingStatusService {
+
+    private final FundingRepository fundingRepository;
+    private final FundingContributionRepository fundingContributionRepository;
+
+    public Funding getByIdOrThrow(Long id) {
+        return fundingRepository.findById(id)
+                .orElseThrow(() -> new ServiceException("404", "존재하지 않는 펀딩입니다."));
+    }
+
+    private void validateOwnership(Funding funding, String userEmail) {
+        if (!funding.getUser().getEmail().equals(userEmail)) {
+            throw new ServiceException("403", "권한이 없습니다.");
+        }
+    }
+
+    // 펀딩 종료
+    @Transactional
+    public void closeFunding(Long fundingId, String userEmail) {
+        Funding funding = getByIdOrThrow(fundingId);
+        validateOwnership(funding, userEmail);
+
+        if (funding.getStatus() != FundingStatus.OPEN) {
+            throw new ServiceException("400", "펀딩이 진행 중 상태가 아닙니다.");
+        }
+        funding.close();
+    }
+
+    // 펀딩 취소
+    @Transactional
+    public void cancelFunding(Long fundingId, String userEmail) {
+        Funding funding = getByIdOrThrow(fundingId);
+        validateOwnership(funding, userEmail);
+
+        if (funding.getStatus() != FundingStatus.OPEN) {
+            throw new ServiceException("400", "펀딩이 진행 중 상태가 아닙니다.");
+        }
+        funding.cancel();
+    }
+
+    @Transactional
+    public int closeExpiredFundings() {
+        LocalDateTime now = LocalDateTime.now();
+
+        // COUNT로 먼저 확인
+        long expiredCount = fundingRepository
+                .countByStatusAndEndDateBefore(FundingStatus.OPEN, now);
+
+        if (expiredCount == 0) {
+            log.debug("[자동 종료] 종료할 펀딩 없음");
+            return 0;
+        }
+
+        log.info("[자동 종료] 종료 대상 펀딩 {}건 발견", expiredCount);
+
+        // 배치 업데이트로 한 번에 처리
+        int closed = fundingRepository.bulkCloseExpiredFundings(now);
+
+        log.info("[자동 종료] 완료 - 처리: {}건", closed);
+
+        return closed;
+    }
+
+    // 모든 CLOSED 펀딩을 최종 처리 (SUCCESS/FAILED)
+    @Transactional
+    public FinalizeResult finalizeAllClosedFundings() {
+        List<Funding> closedFundings = fundingRepository.findByStatus(FundingStatus.CLOSED);
+
+        if (closedFundings.isEmpty()) {
+            log.debug("[최종 처리] 처리할 펀딩 없음");
+            return new FinalizeResult(0, 0, 0);
+        }
+
+        log.info("[최종 처리] 대상 펀딩 {}건", closedFundings.size());
+
+        int successCount = 0;
+        int failedCount = 0;
+        int errorCount = 0;
+
+        for (Funding funding : closedFundings) {
+            try {
+                FinalizeStatus status = processFinalizeLogic(funding);
+
+                if (status == FinalizeStatus.SUCCESS) {
+                    successCount++;
+                } else {
+                    failedCount++;
+                }
+
+            } catch (Exception e) {
+                errorCount++;
+                log.error("[최종 처리] 실패: ID={}", funding.getId(), e);
+            }
+        }
+
+        log.info("[최종 처리] 완료 - 성공: {}건, 실패: {}건, 오류: {}건",
+                successCount, failedCount, errorCount);
+
+        return new FinalizeResult(successCount, failedCount, errorCount);
+    }
+
+    // 단일 펀딩 최종 처리
+    @Transactional
+    public FinalizeStatus finalizeFunding(Long fundingId) {
+        Funding funding = getByIdOrThrow(fundingId);
+        return processFinalizeLogic(funding);
+    }
+
+    // 누락된 펀딩 체크 및 처리 (정합성 체크)
+    @Transactional
+    public int checkAndCloseMissedFundings() {
+        LocalDateTime now = LocalDateTime.now();
+
+        List<Funding> missedFundings = fundingRepository
+                .findByStatusAndEndDateBefore(FundingStatus.OPEN, now);
+
+        if (missedFundings.isEmpty()) {
+            log.info("[정합성 체크] 모든 펀딩 상태 정상");
+            return 0;
+        }
+
+        log.warn("[정합성 체크] 누락된 펀딩 {}건 발견", missedFundings.size());
+
+        int closed = 0;
+        for (Funding funding : missedFundings) {
+            try {
+                funding.close();
+                closed++;
+                log.info("[정합성 체크] 누락 펀딩 종료: ID={}, 종료일={}",
+                        funding.getId(), funding.getEndDate());
+            } catch (Exception e) {
+                log.error("[정합성 체크] 처리 실패: ID={}", funding.getId(), e);
+            }
+        }
+
+        return closed;
+    }
+
+    // 펀딩 최종 처리 핵심 로직 (CLOSED -> SUCCESS/FAILED)
+
+    private FinalizeStatus processFinalizeLogic(Funding funding) {
+        // 상태 체크
+        if (funding.getStatus() != FundingStatus.CLOSED) {
+            throw new ServiceException("400", "종료된 펀딩만 최종 처리할 수 있습니다.");
+        }
+
+        // 실제 모금액 조회
+        Long collectedAmount = fundingContributionRepository
+                .sumContributedAmountByFundingId(funding.getId());
+        long actualAmount = collectedAmount != null ? collectedAmount : 0L;
+
+        // 참여자 수 조회
+        Long participantCount = fundingContributionRepository
+                .countDistinctParticipantsByFundingId(funding.getId());
+        int actualParticipants = participantCount != null ? participantCount.intValue() : 0;
+
+        // 펀딩 엔티티 업데이트
+        funding.increaseCollectedAmount(actualAmount - funding.getCollectedAmount());
+        funding.increaseParticipantCount(actualParticipants - funding.getParticipantCount());
+
+        // 목표 금액 달성 여부에 따라 상태 변경
+        double achievementRate = (actualAmount * 100.0) / funding.getTargetAmount();
+
+        if (actualAmount >= funding.getTargetAmount()) {
+            funding.markAsSuccess();
+            log.info("펀딩 성공: ID={}, 목표={}원, 달성={}원, 달성률={}%",
+                    funding.getId(), funding.getTargetAmount(), actualAmount,
+                    String.format("%.2f", achievementRate));
+            return FinalizeStatus.SUCCESS;
+
+        } else {
+            funding.markAsFailed();
+            log.info("펀딩 실패: ID={}, 목표={}원, 달성={}원, 달성률={}%",
+                    funding.getId(), funding.getTargetAmount(), actualAmount,
+                    String.format("%.2f", achievementRate));
+            return FinalizeStatus.FAILED;
+        }
+    }
+
+    @Transactional
+    public CompleteResult processAllFundings() {
+        log.info("[통합 처리] 시작");
+
+        // 1단계: 만료된 펀딩 종료 (OPEN -> CLOSED)
+        int closedCount = closeExpiredFundings();
+
+        // 2단계: 종료된 펀딩 최종 처리 (CLOSED -> SUCCESS/FAILED)
+        FinalizeResult finalizeResult = finalizeAllClosedFundings();
+
+        log.info("[통합 처리] 완료 - 종료: {}건, 성공: {}건, 실패: {}건",
+                closedCount,
+                finalizeResult.successCount(),
+                finalizeResult.failedCount());
+
+        return new CompleteResult(closedCount, finalizeResult);
+    }
+
+    public record FinalizeResult(
+            int successCount,
+            int failedCount,
+            int errorCount
+    ) {
+        public int totalProcessed() {
+            return successCount + failedCount;
+        }
+    }
+
+    public enum FinalizeStatus {
+        SUCCESS,  // 성공 처리됨
+        FAILED    // 실패 처리됨
+    }
+
+    public record CompleteResult(
+            int closedCount,            // OPEN -> CLOSED 처리된 수
+            int successCount,           // CLOSED -> SUCCESS 처리된 수
+            int failedCount,            // CLOSED -> FAILED 처리된 수
+            int errorCount              // 오류 발생 수
+    ) {
+        public CompleteResult(int closedCount, FinalizeResult finalizeResult) {
+            this(closedCount,
+                    finalizeResult.successCount(),
+                    finalizeResult.failedCount(),
+                    finalizeResult.errorCount());
+        }
+
+        public int totalFinalized() {
+            return successCount + failedCount + errorCount;
+        }
+    }
+}

--- a/src/main/java/com/back/global/initData/TestInitData.java
+++ b/src/main/java/com/back/global/initData/TestInitData.java
@@ -49,10 +49,12 @@ public class TestInitData {
 
     @Transactional
     public void work1() {
+        safeSignup("admin@admin.com", "1234qwer!", "1234qwer!", "관리자", "010-1234-0000");
         safeSignup("user1@user.com", "1234qwer!", "1234qwer!", "유저1", "010-1234-5678");
         safeSignup("user2@user.com", "1234qwer!", "1234qwer!", "유저2", "010-2345-6789");
         safeSignup("user3@user.com", "1234qwer!", "1234qwer!", "유저3", "010-3456-7890");
 
+        devUserService.changeUserRoleByEmail("admin@admin.com", Role.ADMIN);
         devUserService.changeUserRoleByEmail("user1@user.com", Role.ARTIST);
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,6 +21,11 @@ spring:
         format_sql: true
         highlight_sql: true
         use_sql_comments: true
+  task:
+    scheduling:
+      pool:
+        size: 5  # 스케줄러 스레드 풀 크기
+      thread-name-prefix: funding-scheduler-
   # OAuth2 설정
   security:
     oauth2:

--- a/src/test/java/com/back/domain/funding/controller/FundingControllerTest.java
+++ b/src/test/java/com/back/domain/funding/controller/FundingControllerTest.java
@@ -24,6 +24,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest
 @AutoConfigureMockMvc
 @Transactional
+@DisplayName("펀딩 컨트롤러 테스트")
 public class FundingControllerTest {
     @Autowired
     private FundingRepository fundingRepository;

--- a/src/test/java/com/back/domain/funding/controller/FundingStatusControllerTest.java
+++ b/src/test/java/com/back/domain/funding/controller/FundingStatusControllerTest.java
@@ -1,0 +1,123 @@
+package com.back.domain.funding.controller;
+
+import com.back.domain.funding.service.FundingStatusService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@DisplayName("펀딩 상태 관리 컨트롤러 테스트")
+public class FundingStatusControllerTest {
+
+    @Autowired
+    private FundingStatusService fundingStatusService;
+    @Autowired
+    private MockMvc mvc;
+
+    @Test
+    @DisplayName("펀딩 종료 - 성공")
+    @WithMockUser("user1@user.com")
+    void t1() throws Exception{
+
+        ResultActions resultActions = mvc.perform(put("/api/fundings/1/close")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print());
+
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.msg").value("펀딩이 종료되었습니다."));
+    }
+
+    @Test
+    @DisplayName("펀딩 종료 - 실패 - 권한 없음")
+    @WithMockUser("user2@user.com")
+    void t2() throws Exception{
+        ResultActions resultActions = mvc.perform(put("/api/fundings/1/close")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print());
+
+        resultActions.andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.msg").value("권한이 없습니다."));
+    }
+
+    @Test
+    @DisplayName("펀딩 종료 - 실패 - 이미 종료된 펀딩")
+    @WithMockUser("user1@user.com")
+    void t3() throws Exception{
+        Long fundingId = 1L;
+        fundingStatusService.closeFunding(fundingId, "user1@user.com");
+
+        ResultActions resultActions = mvc.perform(put("/api/fundings/1/close")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print());
+
+        resultActions.andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.msg").value("펀딩이 진행 중 상태가 아닙니다."));
+    }
+
+    @Test
+    @DisplayName("펀딩 취소 - 성공")
+    @WithMockUser("user1@user.com")
+    void t4() throws Exception{
+        ResultActions resultActions = mvc.perform(put("/api/fundings/1/cancel")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print());
+
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.msg").value("펀딩이 취소되었습니다."));
+    }
+
+    @Test
+    @DisplayName("펀딩 취소 - 실패 - 권한 없음")
+    @WithMockUser("user2@user.com")
+    void t5() throws Exception{
+        ResultActions resultActions = mvc.perform(put("/api/fundings/1/cancel")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print());
+
+        resultActions.andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.msg").value("권한이 없습니다."));
+    }
+
+    @Test
+    @DisplayName("펀딩 취소 - 실패 - 이미 종료된 펀딩")
+    @WithMockUser("user1@user.com")
+    void t6() throws Exception{
+        Long fundingId = 1L;
+        fundingStatusService.closeFunding(fundingId, "user1@user.com");
+        ResultActions resultActions = mvc.perform(put("/api/fundings/1/cancel")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print());
+        resultActions.andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.msg").value("펀딩이 진행 중 상태가 아닙니다."));
+    }
+
+//    @Test
+//    @DisplayName("펀딩 최종 처리 - 성공")
+//    @WithMockUser("admin@admin.com")
+//    void t7() throws Exception{
+//        Long fundingId = 1L;
+//        fundingStatusService.closeFunding(fundingId, "user1@user.com");
+//        ResultActions resultActions = mvc.perform(put("/api/fundings/1/finalize")
+//                        .accept(MediaType.APPLICATION_JSON))
+//                .andDo(print());
+//
+//        resultActions.andExpect(status().isOk())
+//                .andExpect(jsonPath("$.msg").value("펀딩 최종 처리가 완료되었습니다."));
+//    }
+}


### PR DESCRIPTION
## 📢 기능 설명

펀딩 상태 변경 관련 로직 구현
펀딩 취소, 종료, 종료된 펀딩 성공 실패 상태 변경 가능
한시간 단위로 스케줄러를 통해 자동 상태 변경
<br>

<img width="1566" height="651" alt="스크린샷 2025-09-30 17 18 35" src="https://github.com/user-attachments/assets/ff29ca41-8281-43bd-b2a0-28d7b9cea160" />
- 스케줄러로 기간 만료된 펀딩 조회 후 완료 상태 변경
<br><br>

<img width="585" height="35" alt="스크린샷 2025-09-30 17 19 25" src="https://github.com/user-attachments/assets/eaeea9f2-5bb8-4f8c-957f-7db66dc97024" />
<br>
- 완료 상태 변경 후 조건에 따라 성공 실패 상태로 변경
<br><br>


<img width="1523" height="764" alt="스크린샷 2025-09-30 17 19 44" src="https://github.com/user-attachments/assets/3597ef90-c18b-4652-b458-18d185fcfd37" />
- 처리할 펀딩이 없는 경우

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #{이슈넘버}
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?
