### PR TITLE
[feat] ArtistController 구현

### DIFF
--- a/src/main/java/com/back/domain/artist/controller/ArtistController.java
+++ b/src/main/java/com/back/domain/artist/controller/ArtistController.java
@@ -1,0 +1,100 @@
+package com.back.domain.artist.controller;
+
+import com.back.domain.artist.dto.request.ArtistApplicationRequest;
+import com.back.domain.artist.dto.response.ArtistApplicationResponse;
+import com.back.domain.artist.dto.response.ArtistApplicationSimpleResponse;
+import com.back.domain.artist.service.ArtistApplicationService;
+import com.back.global.rsData.RsData;
+import com.back.global.security.auth.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/artist")
+@RequiredArgsConstructor
+@Tag(name = "작가", description = "작가 관련 API")
+public class ArtistController {
+
+    private final ArtistApplicationService artistApplicationService;
+
+    /**
+     * 작가 신청
+     */
+    @PostMapping("/application")
+    @Operation(summary = "작가 신청", description = "사용자가 작가로 신청합니다.")
+    public ResponseEntity<RsData<Long>> applyForArtist(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody ArtistApplicationRequest request) {
+
+        log.info("작가 신청 - userId: {}", userDetails.getUserId());
+
+        Long applicationId = artistApplicationService.createApplication(userDetails.getUserId(), request);
+
+        return ResponseEntity.ok(
+                RsData.of("200", "작가 신청 완료", applicationId)
+        );
+    }
+
+    /**
+     * 내 작가 신청 목록 조회
+     */
+    @GetMapping("/application/me")
+    @Operation(summary = "내 작가 신청 목록 조회", description = "본인의 작가 신청서 목록을 조회합니다.")
+    public ResponseEntity<RsData<List<ArtistApplicationSimpleResponse>>> getMyArtistApplications(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        log.info("내 작가 신청 목록 조회 - userId: {}", userDetails.getUserId());
+
+        List<ArtistApplicationSimpleResponse> response = artistApplicationService.getMyApplications(userDetails.getUserId());
+
+        return ResponseEntity.ok(
+                RsData.of("200", "내 작가 신청 목록 조회 성공", response)
+        );
+    }
+
+    /**
+     * 작가 신청 상세 조회
+     */
+    @GetMapping("/application/{applicationId}")
+    @Operation(summary = "작가 신청 상세 조회", description = "특정 작가 신청서의 상세 정보를 조회합니다.")
+    public ResponseEntity<RsData<ArtistApplicationResponse>> getArtistApplicationDetail(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long applicationId) {
+
+        log.info("작가 신청 상세 조회 - userId: {}, applicationId: {}",
+                userDetails.getUserId(), applicationId);
+
+        ArtistApplicationResponse response =
+                artistApplicationService.getApplicationById(userDetails.getUserId(), applicationId);
+
+        return ResponseEntity.ok(
+                RsData.of("200", "작가 신청 상세 조회 성공", response)
+        );
+    }
+
+    /**
+     * 작가 신청 취소/삭제
+     */
+    @DeleteMapping("/application/{applicationId}/cancel")
+    public ResponseEntity<RsData<Void>> cancelArtistApplication(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long applicationId) {
+        log.info("작가 신청 취소 - userId: {}, applicationId: {}",
+                userDetails.getUserId(), applicationId);
+
+        artistApplicationService.cancelApplication(userDetails.getUserId(), applicationId);
+
+        return ResponseEntity.ok(
+                RsData.of("200", "작가 신청 취소 성공")
+        );
+    }
+}

--- a/src/main/java/com/back/domain/artist/service/ArtistApplicationService.java
+++ b/src/main/java/com/back/domain/artist/service/ArtistApplicationService.java
@@ -93,8 +93,48 @@ public class ArtistApplicationService {
         return ArtistApplicationResponse.from(application);
     }
 
+    /**
+     * 작가 신청 취소 (삭제)
+     */
+    @Transactional
+    public void cancelApplication(Long userId, Long applicationId) {
+        // 1. 신청서 조회
+        ArtistApplication application = getApplicationIfOwner(userId, applicationId);
+
+        // 2. 취소 가능한 상태인지 확인
+        validateCancellable(application);
+
+        // 3. 신청서 삭제
+        artistApplicationRepository.delete(application);
+
+        log.info("작가 신청 취소 완료: userId={}, applicationId={}", userId, applicationId);
+    }
+
 
     // ==== 헬퍼 메서드 ==== //
+
+    /**
+     * 신청소 조회 및 소유권 검증
+     */
+    private ArtistApplication getApplicationIfOwner(Long userId, Long applicationId) {
+        ArtistApplication application = artistApplicationRepository.findById(applicationId)
+                .orElseThrow(() -> new ServiceException("404", "신청서를 찾을 수 없습니다."));
+
+        if (!application.getUser().getId().equals(userId)) {
+            throw new ServiceException("403", "본인의 신청서만 접근할 수 있습니다.");
+        }
+
+        return application;
+    }
+
+    /**
+     * 신청서 취소 가능 여부 검증
+     */
+    private void validateCancellable(ArtistApplication application) {
+        if (!application.isPending()) {
+            throw new ServiceException("400", "심사 대기 중인 신청서만 취소할 수 있습니다. 현재 상태: " + application.getStatus());
+        }
+    }
 
     /**
      * 중복 신청 검증

--- a/src/test/java/com/back/domain/artist/controller/ArtistControllerTest.java
+++ b/src/test/java/com/back/domain/artist/controller/ArtistControllerTest.java
@@ -1,0 +1,454 @@
+package com.back.domain.artist.controller;
+
+import com.back.domain.artist.entity.ArtistApplication;
+import com.back.domain.artist.repository.ArtistApplicationRepository;
+import com.back.domain.user.entity.User;
+import com.back.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithUserDetails;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@DisplayName("작가 컨트롤러 테스트")
+class ArtistControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ArtistApplicationRepository artistApplicationRepository;
+
+    @Test
+    @WithUserDetails("user2@user.com")
+    @DisplayName("1. 작가 신청 - 성공")
+    void t1() throws Exception {
+        // when
+        ResultActions resultActions = mvc.perform(post("/api/artist/application")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "ownerName": "홍길동",
+                                  "email": "artist@example.com",
+                                  "phone": "010-1234-5678",
+                                  "artistName": "작가홍길동",
+                                  "businessNumber": "123-45-67890",
+                                  "businessName": "홍길동 작가실",
+                                  "businessAddress": "서울시 강남구 테헤란로",
+                                  "businessAddressDetail": "123번지 2층",
+                                  "businessZipCode": "12345",
+                                  "telecomSalesNumber": "2023-서울강남-0001",
+                                  "snsAccount": "@artist_hong",
+                                  "mainProducts": "회화, 조각",
+                                  "managerPhone": "010-9876-5432",
+                                  "bankName": "신한은행",
+                                  "bankAccount": "110-123-456789",
+                                  "accountName": "홍길동",
+                                  "documents": {
+                                    "BUSINESS_LICENSE": [
+                                      {
+                                        "fileKey": "documents/business_license.pdf",
+                                        "fileName": "사업자등록증.pdf",
+                                        "fileUrl": "https://example.com/business_license.pdf"
+                                      }
+                                    ],
+                                    "TELECOM_CERTIFICATION": [
+                                      {
+                                        "fileKey": "documents/telecom_cert.pdf",
+                                        "fileName": "통신판매업신고증.pdf",
+                                        "fileUrl": "https://example.com/telecom_cert.pdf"
+                                      }
+                                    ]
+                                  }
+                                }
+                                """))
+                .andDo(print());
+
+        // then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value("200"))
+                .andExpect(jsonPath("$.msg").value("작가 신청 완료"))
+                .andExpect(jsonPath("$.data").isNumber());
+    }
+
+    @Test
+    @DisplayName("2. 작가 신청 - 실패 (미인증)")
+    void t2() throws Exception {
+        // when
+        ResultActions resultActions = mvc.perform(post("/api/artist/application")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "ownerName": "홍길동",
+                                  "email": "artist@example.com",
+                                  "phone": "010-1234-5678",
+                                  "artistName": "작가홍길동",
+                                  "businessNumber": "123-45-67890",
+                                  "businessAddress": "서울시 강남구",
+                                  "businessAddressDetail": "123번지",
+                                  "businessZipCode": "12345",
+                                  "telecomSalesNumber": "2023-서울강남-0001",
+                                  "documents": {}
+                                }
+                                """))
+                .andDo(print());
+
+        // then
+        resultActions.andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithUserDetails("user2@user.com")
+    @DisplayName("3. 작가 신청 - 실패 (필수 서류 누락)")
+    void t3() throws Exception {
+        // when
+        ResultActions resultActions = mvc.perform(post("/api/artist/application")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "ownerName": "홍길동",
+                                  "email": "artist@example.com",
+                                  "phone": "010-1234-5678",
+                                  "artistName": "작가홍길동",
+                                  "businessNumber": "123-45-67890",
+                                  "businessAddress": "서울시 강남구",
+                                  "businessAddressDetail": "123번지",
+                                  "businessZipCode": "12345",
+                                  "telecomSalesNumber": "2023-서울강남-0001",
+                                  "documents": {
+                                    "BUSINESS_LICENSE": [
+                                      {
+                                        "fileKey": "documents/business_license.pdf",
+                                        "fileName": "사업자등록증.pdf",
+                                        "fileUrl": "https://example.com/business_license.pdf"
+                                      }
+                                    ]
+                                  }
+                                }
+                                """))
+                .andDo(print());
+
+        // then
+        resultActions.andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.msg").value("필수 서류가 누락되었습니다.통신판매업신고증"));
+    }
+
+    @Test
+    @WithUserDetails("user2@user.com")
+    @DisplayName("4. 작가 신청 - 실패 (필수 필드 누락)")
+    void t4() throws Exception {
+        // when - ownerName 누락
+        ResultActions resultActions = mvc.perform(post("/api/artist/application")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "email": "artist@example.com",
+                                  "phone": "010-1234-5678",
+                                  "artistName": "작가홍길동",
+                                  "businessNumber": "123-45-67890",
+                                  "businessAddress": "서울시 강남구",
+                                  "businessAddressDetail": "123번지",
+                                  "businessZipCode": "12345",
+                                  "telecomSalesNumber": "2023-서울강남-0001",
+                                  "documents": {}
+                                }
+                                """))
+                .andDo(print());
+
+        // then
+        resultActions.andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithUserDetails("user2@user.com")
+    @DisplayName("5. 내 작가 신청 목록 조회 - 성공")
+    void t5() throws Exception {
+        // given - 신청서 생성
+        User user = userRepository.findByEmail("user2@user.com").orElseThrow();
+        ArtistApplication application = ArtistApplication.builder()
+                .user(user)
+                .ownerName("홍길동")
+                .email("artist@example.com")
+                .phone("010-1234-5678")
+                .artistName("작가홍길동")
+                .businessNumber("123-45-67890")
+                .businessName("홍길동 작가실")
+                .businessAddress("서울시 강남구")
+                .businessAddressDetail("123번지")
+                .businessZipCode("12345")
+                .telecomSalesNumber("2023-서울강남-0001")
+                .bankName("신한은행")
+                .bankAccount("110-123-456789")
+                .accountName("홍길동")
+                .build();
+        artistApplicationRepository.save(application);
+
+        // when
+        ResultActions resultActions = mvc.perform(get("/api/artist/application/me")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print());
+
+        // then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value("200"))
+                .andExpect(jsonPath("$.msg").value("내 작가 신청 목록 조회 성공"))
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data[0].id").value(application.getId()))
+                .andExpect(jsonPath("$.data[0].artistName").value("작가홍길동"))
+                .andExpect(jsonPath("$.data[0].status").value("PENDING"));
+    }
+
+    @Test
+    @DisplayName("6. 내 작가 신청 목록 조회 - 실패 (미인증)")
+    void t6() throws Exception {
+        // when
+        ResultActions resultActions = mvc.perform(get("/api/artist/application/me")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print());
+
+        // then
+        resultActions.andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithUserDetails("user2@user.com")
+    @DisplayName("7. 작가 신청 상세 조회 - 성공")
+    void t7() throws Exception {
+        // given
+        User user = userRepository.findByEmail("user2@user.com").orElseThrow();
+        ArtistApplication application = ArtistApplication.builder()
+                .user(user)
+                .ownerName("홍길동")
+                .email("artist@example.com")
+                .phone("010-1234-5678")
+                .artistName("작가홍길동")
+                .businessNumber("123-45-67890")
+                .businessName("홍길동 작가실")
+                .businessAddress("서울시 강남구")
+                .businessAddressDetail("123번지")
+                .businessZipCode("12345")
+                .telecomSalesNumber("2023-서울강남-0001")
+                .snsAccount("@artist_hong")
+                .mainProducts("회화, 조각")
+                .bankName("신한은행")
+                .bankAccount("110-123-456789")
+                .accountName("홍길동")
+                .build();
+        artistApplicationRepository.save(application);
+
+        // when
+        ResultActions resultActions = mvc.perform(get("/api/artist/application/" + application.getId())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print());
+
+        // then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value("200"))
+                .andExpect(jsonPath("$.msg").value("작가 신청 상세 조회 성공"))
+                .andExpect(jsonPath("$.data.id").value(application.getId()))
+                .andExpect(jsonPath("$.data.ownerName").value("홍길동"))
+                .andExpect(jsonPath("$.data.email").value("artist@example.com"))
+                .andExpect(jsonPath("$.data.artistName").value("작가홍길동"))
+                .andExpect(jsonPath("$.data.businessNumber").value("123-45-67890"))
+                .andExpect(jsonPath("$.data.status").value("PENDING"));
+    }
+
+    @Test
+    @WithUserDetails("user2@user.com")
+    @DisplayName("8. 작가 신청 상세 조회 - 실패 (다른 사용자의 신청서)")
+    void t8() throws Exception {
+        // given - user1의 신청서 생성
+        User user1 = userRepository.findByEmail("user1@user.com").orElseThrow();
+        ArtistApplication application = ArtistApplication.builder()
+                .user(user1)
+                .ownerName("김철수")
+                .email("kim@example.com")
+                .phone("010-9999-8888")
+                .artistName("작가김철수")
+                .businessNumber("999-88-77777")
+                .businessAddress("서울시 종로구")
+                .businessAddressDetail("456번지")
+                .businessZipCode("54321")
+                .telecomSalesNumber("2023-서울종로-0002")
+                .bankName("국민은행")
+                .bankAccount("220-987-654321")
+                .accountName("김철수")
+                .build();
+        artistApplicationRepository.save(application);
+
+        // when - user2가 user1의 신청서 조회 시도
+        ResultActions resultActions = mvc.perform(get("/api/artist/application/" + application.getId())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print());
+
+        // then
+        resultActions.andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.msg").value("본인의 신청서만 조회할 수 있습니다."));
+    }
+
+    @Test
+    @WithUserDetails("user2@user.com")
+    @DisplayName("9. 작가 신청 상세 조회 - 실패 (존재하지 않는 신청서)")
+    void t9() throws Exception {
+        // when
+        ResultActions resultActions = mvc.perform(get("/api/artist/application/99999")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print());
+
+        // then
+        resultActions.andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.msg").value("신청서를 찾을 수 없습니다."));
+    }
+
+    @Test
+    @WithUserDetails("user2@user.com")
+    @DisplayName("10. 작가 신청 취소 - 성공")
+    void t10() throws Exception {
+        // given
+        User user = userRepository.findByEmail("user2@user.com").orElseThrow();
+        ArtistApplication application = ArtistApplication.builder()
+                .user(user)
+                .ownerName("홍길동")
+                .email("artist@example.com")
+                .phone("010-1234-5678")
+                .artistName("작가홍길동")
+                .businessNumber("123-45-67890")
+                .businessAddress("서울시 강남구")
+                .businessAddressDetail("123번지")
+                .businessZipCode("12345")
+                .telecomSalesNumber("2023-서울강남-0001")
+                .bankName("신한은행")
+                .bankAccount("110-123-456789")
+                .accountName("홍길동")
+                .build();
+        artistApplicationRepository.save(application);
+
+        // when
+        ResultActions resultActions = mvc.perform(delete("/api/artist/application/" + application.getId() + "/cancel")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print());
+
+        // then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value("200"))
+                .andExpect(jsonPath("$.msg").value("작가 신청 취소 성공"));
+
+        // 신청서가 삭제되었는지 확인
+        assertThat(artistApplicationRepository.findById(application.getId())).isEmpty();
+    }
+
+    @Test
+    @WithUserDetails("user2@user.com")
+    @DisplayName("11. 작가 신청 취소 - 실패 (승인된 신청서)")
+    void t11() throws Exception {
+        // given - 승인된 신청서
+        User user = userRepository.findByEmail("user2@user.com").orElseThrow();
+        ArtistApplication application = ArtistApplication.builder()
+                .user(user)
+                .ownerName("홍길동")
+                .email("artist@example.com")
+                .phone("010-1234-5678")
+                .artistName("작가홍길동")
+                .businessNumber("123-45-67890")
+                .businessAddress("서울시 강남구")
+                .businessAddressDetail("123번지")
+                .businessZipCode("12345")
+                .telecomSalesNumber("2023-서울강남-0001")
+                .bankName("신한은행")
+                .bankAccount("110-123-456789")
+                .accountName("홍길동")
+                .build();
+        artistApplicationRepository.save(application);
+
+        // 승인 처리
+        application.approve(1L, "관리자");
+        artistApplicationRepository.save(application);
+
+        // when
+        ResultActions resultActions = mvc.perform(delete("/api/artist/application/" + application.getId() + "/cancel")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print());
+
+        // then
+        resultActions.andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.msg").value("심사 대기 중인 신청서만 취소할 수 있습니다. 현재 상태: APPROVED"));
+    }
+
+    @Test
+    @WithUserDetails("user2@user.com")
+    @DisplayName("12. 작가 신청 취소 - 실패 (다른 사용자의 신청서)")
+    void t12() throws Exception {
+        // given - user1의 신청서
+        User user1 = userRepository.findByEmail("user1@user.com").orElseThrow();
+        ArtistApplication application = ArtistApplication.builder()
+                .user(user1)
+                .ownerName("김철수")
+                .email("kim@example.com")
+                .phone("010-9999-8888")
+                .artistName("작가김철수")
+                .businessNumber("999-88-77777")
+                .businessAddress("서울시 종로구")
+                .businessAddressDetail("456번지")
+                .businessZipCode("54321")
+                .telecomSalesNumber("2023-서울종로-0002")
+                .bankName("국민은행")
+                .bankAccount("220-987-654321")
+                .accountName("김철수")
+                .build();
+        artistApplicationRepository.save(application);
+
+        // when - user2가 user1의 신청서 취소 시도
+        ResultActions resultActions = mvc.perform(delete("/api/artist/application/" + application.getId() + "/cancel")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print());
+
+        // then
+        resultActions.andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.msg").value("본인의 신청서만 접근할 수 있습니다."));
+    }
+
+    @Test
+    @DisplayName("13. 작가 신청 취소 - 실패 (미인증)")
+    void t13() throws Exception {
+        // when
+        ResultActions resultActions = mvc.perform(delete("/api/artist/application/1/cancel")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print());
+
+        // then
+        resultActions.andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithUserDetails("user2@user.com")
+    @DisplayName("14. 작가 신청 취소 - 실패 (존재하지 않는 신청서)")
+    void t14() throws Exception {
+        // when
+        ResultActions resultActions = mvc.perform(delete("/api/artist/application/99999/cancel")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print());
+
+        // then
+        resultActions.andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.msg").value("신청서를 찾을 수 없습니다."));
+    }
+}


### PR DESCRIPTION
## 📢 기능 설명

### ArtistController 구현
- 작가 신청 / 내 작가신청목록 조회 / 내 작가 신청서 상세 조회 / 작가 신청 취소 4개 API 구현
- Test코드는 AI로 작성 
- 작가 취소 로직 Service에 추가

### TODO 작가 프로필 엔티티/리포지토리/서비스 생성 후, 관리자가 작가 승인/거절 API 추가 필요

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #148 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?
