### PR TITLE
[fix] Set-Cookie 헤더 설정 방식 개선

### DIFF
--- a/src/main/java/com/back/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/back/domain/auth/controller/AuthController.java
@@ -18,6 +18,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -90,9 +91,13 @@ public class AuthController {
         ResponseCookie refreshTokenCookie = createTokenCookie("refreshToken", response.refreshToken(), 7 * 24 * 60 * 60);
         ResponseCookie accessTokenCookie = createTokenCookie("accessToken", response.accessToken(), 15 * 60);
 
+        // HttpHeaders를 사용하여 여러 Set-Cookie 헤더 추가
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
+        headers.add(HttpHeaders.SET_COOKIE, accessTokenCookie.toString());
+
         return ResponseEntity.ok()
-                .header("Set-Cookie", refreshTokenCookie.toString())
-                .header("Set-Cookie", accessTokenCookie.toString())
+                .headers(headers)
                 .body(RsData.of("200", "로그인 성공", response));
     }
 
@@ -106,9 +111,12 @@ public class AuthController {
     ) {
         authService.logout(request.refreshToken());
 
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.SET_COOKIE, deleteCookie("refreshToken").toString());
+        headers.add(HttpHeaders.SET_COOKIE, deleteCookie("accessToken").toString());
+
         return ResponseEntity.ok()
-                .header("Set-Cookie", deleteCookie("refreshToken").toString())
-                .header("Set-Cookie", deleteCookie("accessToken").toString())
+                .headers(headers)
                 .body(RsData.of("200", "로그아웃 성공"));
     }
 


### PR DESCRIPTION
## 📢 기능 설명

Set-Cookie 헤더 설정 방식 개선

로그인/로그아웃시 accessToken, refreshToken 쿠키 설정 로직 수정

기존에 사용하던 .header() 방법이 헤더명 중복 덮어쓰기 위험이 존재했음

-> Httpheaders.add() 방식으로 변경해서 acesss/refresh Token 모두 안전하게 전송되도록 수정

Front로그아웃 오류가 혹시 해결될까 싶어 시도해봤음


## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #176 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?
