### PR TITLE
[fix] 소셜 로그인, 중복인증 버그 수정

### DIFF
--- a/src/main/java/com/back/domain/auth/service/AuthService.java
+++ b/src/main/java/com/back/domain/auth/service/AuthService.java
@@ -249,12 +249,12 @@ public class AuthService {
         User user = userRepository.findByEmail(request.email())
                 .orElseThrow(() -> {
                     log.warn("로그인 실패 - 존재하지 않는 이메일: {}", request.email());
-                    return new ServiceException("401", "이메일 또는 비밀번호가 잘못되었습니다.");
+                    return new ServiceException("401", "이메일이 잘못되었습니다.");
                 });
 
         if (!passwordEncoder.matches(request.password(), user.getPassword())) {
             log.warn("로그인 실패 - 비밀번호 불일치: email={}", request.email());
-            throw new ServiceException("401", "이메일 또는 비밀번호가 잘못되었습니다.");
+            throw new ServiceException("401", "비밀번호가 잘못되었습니다.");
         }
 
         if (!user.getRole().canLoginAs(request.selectedRole())) {

--- a/src/main/java/com/back/domain/auth/service/AuthService.java
+++ b/src/main/java/com/back/domain/auth/service/AuthService.java
@@ -247,13 +247,19 @@ public class AuthService {
      */
     private User validateLoginCredentials(LoginRequest request) {
         User user = userRepository.findByEmail(request.email())
-                .orElseThrow(() -> new ServiceException("401", "이메일 또는 비밀번호가 잘못되었습니다."));
+                .orElseThrow(() -> {
+                    log.warn("로그인 실패 - 존재하지 않는 이메일: {}", request.email());
+                    return new ServiceException("401", "이메일 또는 비밀번호가 잘못되었습니다.");
+                });
 
         if (!passwordEncoder.matches(request.password(), user.getPassword())) {
+            log.warn("로그인 실패 - 비밀번호 불일치: email={}", request.email());
             throw new ServiceException("401", "이메일 또는 비밀번호가 잘못되었습니다.");
         }
 
         if (!user.getRole().canLoginAs(request.selectedRole())) {
+            log.warn("로그인 실패 - 권한 불일치: email={}, requestedRole={}, userRole={}",
+                    request.email(), request.selectedRole(), user.getRole());
             throw new ServiceException("403", "선택한 역할로 로그인할 수 없습니다.");
         }
 

--- a/src/main/java/com/back/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/back/global/security/config/SecurityConfig.java
@@ -49,13 +49,20 @@ public class SecurityConfig {
         http
                 // URL별 권한 설정
                 .authorizeHttpRequests(auth -> auth
-                        // 인증이 필요 없는 API
+                        // ========================================
+                        // 🔓 인증 불필요 - 공개 API
+                        // ========================================
+
+                        // 인증/인가 - 회원가입, 로그인, 토큰 관련
                         .requestMatchers("/api/auth/signup", "/api/auth/login", "/api/auth/refresh", "/api/auth/logout").permitAll()
 
-                        // OAuth2 로그인 엔드포인트 - 인증 불필요
+                        // 중복 검증 - 이메일, 닉네임, 전화번호
+                        .requestMatchers("/api/auth/duplicate/**").permitAll()
+
+                        // OAuth2 로그인 엔드포인트
                         .requestMatchers("/oauth2/**", "/login/oauth2/**").permitAll()
 
-                        // 공개 API - 로그인 없이 접근 허용
+                        // 공개 API
                         .requestMatchers("/public/**").permitAll()
 
                         // 상품/카테고리/태그 조회 - 로그인 없이 접근 허용

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -40,4 +40,4 @@ app:
   cookie:
     secure: true
     domain: .mori-mori.store
-  frontend-url: ${FRONTEND_URL:https://mori-mori.store}
+  frontend-url: https://www.mori-mori.store

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -88,7 +88,7 @@ app:
   cookie:
     secure: false
     domain: localhost
-  frontend-url: ${FRONTEND_URL:https://mori-mori.store}
+  frontend-url: http://localhost:3000
 
 # JWT 설정 (.env 파일 없어도 동작하도록 기본값 제공)
 jwt:


### PR DESCRIPTION
## 📢 기능 설명

- 소셜 로그인 Frontend 리다이렉트 URL 환경변수 처리 (배포 환경에서 리다이렉트가 localhost:3000으로 되는 버그가 있었음)
   -> yml에 리다이렉트 URL 값 직접 넣는 방법으로 수정 
- 중복 검증 SecurityConfig에 권한 비허가 버그 수정
- 로그인 실패 시, 이메일 & 비밀번호 어떤 것이 실패했는지 유추 가능한 메시지로 변경 -> 보안적으로 문제가 있지만, 편의성을 위해 허용

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #240 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?
