### PR TITLE
[feat] 작가 공개 정보 조회 API 구현

### DIFF
--- a/src/main/java/com/back/domain/artist/controller/ArtistController.java
+++ b/src/main/java/com/back/domain/artist/controller/ArtistController.java
@@ -1,17 +1,19 @@
 package com.back.domain.artist.controller;
 
 import com.back.domain.artist.dto.request.ArtistApplicationRequest;
-import com.back.domain.artist.dto.response.ArtistApplicationResponse;
-import com.back.domain.artist.dto.response.ArtistApplicationSimpleResponse;
-import com.back.domain.artist.dto.response.ArtistBusinessInfoResponse;
+import com.back.domain.artist.dto.response.*;
 import com.back.domain.artist.service.ArtistApplicationService;
+import com.back.domain.artist.service.ArtistPublicService;
 import com.back.global.rsData.RsData;
 import com.back.global.security.auth.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -26,6 +28,84 @@ import java.util.List;
 public class ArtistController {
 
     private final ArtistApplicationService artistApplicationService;
+    private final ArtistPublicService artistPublicService;
+
+    // ========================================
+    // 공개 API
+    // ========================================
+
+    /**
+     * 전체 작가 목록 조회
+     */
+    @GetMapping("/list")
+    @Operation(
+            summary = "전체 작가 목록 조회",
+            description = "등록된 모든 작가의 ID와 이름을 조회합니다."
+    )
+    public ResponseEntity<RsData<List<ArtistListResponse>>> getArtistList() {
+
+        log.info("작가 목록 조회");
+
+        List<ArtistListResponse> response = artistPublicService.getArtistList();
+
+        return ResponseEntity.ok(
+                RsData.of("200", "작가 목록 조회 성공", response)
+        );
+    }
+
+    /**
+     * 작가 공개 프로필 상세 조회
+     */
+    @GetMapping("/profile/{artistId}")
+    @Operation(
+            summary = "작가 공개 프로필 상세 조회",
+            description = "작가의 공개 프로필 상세 정보를 조회합니다."
+    )
+    public ResponseEntity<RsData<ArtistPublicProfileResponse>> getArtistPublicProfile(
+            @Parameter(description = "작가 ID", example = "42", required = true)
+            @PathVariable Long artistId) {
+
+        log.info("작가 공개 프로필 조회 - artistId: {}", artistId);
+
+        ArtistPublicProfileResponse response = artistPublicService.getPublicProfile(artistId);
+
+        return ResponseEntity.ok(
+                RsData.of("200", "작가 프로필 조회 성공", response)
+        );
+    }
+
+    /**
+     * 작가의 상품 목록 조회
+     */
+    @GetMapping("/profile/{artistId}/products")
+    @Operation(
+            summary = "작가의 상품 목록 조회",
+            description = "특정 작가가 등록한 모든 상품을 조회합니다."
+    )
+    public ResponseEntity<RsData<List<ArtistProductResponse>>> getArtistProducts(
+            @Parameter(description = "작가 ID", example = "42", required = true)
+            @PathVariable Long artistId,
+
+            @Parameter(description = "페이지 번호 (1부터 시작)", example = "1")
+            @RequestParam(defaultValue = "1") int page,
+
+            @Parameter(description = "페이지 크기", example = "12")
+            @RequestParam(defaultValue = "12") int size) {
+
+        log.info("작가 상품 목록 조회 - artistId: {}, page: {}, size: {}", artistId, page, size);
+
+        Pageable pageable = PageRequest.of(page - 1, size);
+        List<ArtistProductResponse> response = artistPublicService.getArtistProducts(artistId, pageable);
+
+        return ResponseEntity.ok(
+                RsData.of("200", "작가 상품 목록 조회 성공", response)
+        );
+    }
+
+
+    // ========================================
+    // 인증 필요 API
+    // ========================================
 
     /**
      * 작가 신청

--- a/src/main/java/com/back/domain/artist/dto/response/ArtistListResponse.java
+++ b/src/main/java/com/back/domain/artist/dto/response/ArtistListResponse.java
@@ -1,0 +1,23 @@
+package com.back.domain.artist.dto.response;
+
+import com.back.domain.artist.entity.ArtistProfile;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * 작가 목록 항목 DTO (간소화 버전)
+ */
+@Schema(description = "작가 목록 항목")
+public record ArtistListResponse (
+    @Schema(description = "작가 ID", example = "42")
+    Long artistId,
+
+    @Schema(description = "작가명", example = "김도예")
+    String artistName
+) {
+        public static ArtistListResponse from(ArtistProfile artistProfile) {
+            return new ArtistListResponse(
+                    artistProfile.getUser().getId(),
+                    artistProfile.getArtistName()
+            );
+        }
+    }

--- a/src/main/java/com/back/domain/artist/dto/response/ArtistProductResponse.java
+++ b/src/main/java/com/back/domain/artist/dto/response/ArtistProductResponse.java
@@ -1,0 +1,42 @@
+package com.back.domain.artist.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.UUID;
+
+/**
+ * 작가 상품 응답 DTO
+ */
+@Schema(description = "작가 상품 정보")
+public record ArtistProductResponse(
+        @Schema(description = "상품 UUID", example = "550e8400-e29b-41d4-a716-446655440000")
+        UUID productUuid,
+
+        @Schema(description = "상품명", example = "핸드메이드 머그컵")
+        String name,
+
+        @Schema(description = "정가", example = "25000")
+        Integer price,
+
+        @Schema(description = "할인가", example = "20000")
+        Integer discountPrice,
+
+        @Schema(description = "할인율", example = "20")
+        Integer discountRate,
+
+        @Schema(description = "썸네일 이미지 URL", example = "https://example.com/thumbnail.jpg")
+        String thumbnailUrl,
+
+        @Schema(description = "평균 평점", example = "4.5")
+        Double rating,
+
+        @Schema(description = "리뷰 수", example = "35")
+        Long reviewCount,
+
+        @Schema(description = "재고 수량", example = "10")
+        Integer stock,
+
+        @Schema(description = "판매 상태", example = "SELLING")
+        String sellingStatus
+) {
+}

--- a/src/main/java/com/back/domain/artist/dto/response/ArtistPublicProfileResponse.java
+++ b/src/main/java/com/back/domain/artist/dto/response/ArtistPublicProfileResponse.java
@@ -1,0 +1,56 @@
+package com.back.domain.artist.dto.response;
+
+import com.back.domain.artist.entity.ArtistProfile;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+/**
+ * 작가 공개 프로필 응답 DTO
+ */
+@Schema(description = "작가 공개 프로필 정보")
+public record ArtistPublicProfileResponse(
+        @Schema(description = "작가 ID", example = "42")
+        Long artistId,
+
+        @Schema(description = "작가명", example = "김도예")
+        String artistName,
+
+        @Schema(description = "프로필 이미지 URL", example = "https://example.com/profile.jpg")
+        String profileImageUrl,
+
+        @Schema(description = "작가 소개", example = "전통 도자기를 현대적으로 재해석하는 작가입니다.")
+        String description,
+
+        @Schema(description = "주력 상품", example = "도자기, 머그컵")
+        String mainProducts,
+
+        @Schema(description = "SNS 계정", example = "@artist_kim")
+        String snsAccount,
+
+        @Schema(description = "팔로워 수", example = "1250")
+        Integer followerCount,
+
+        @Schema(description = "총 판매액", example = "5000000")
+        Long totalSales,
+
+        @Schema(description = "등록 상품 수", example = "15")
+        Integer productCount,
+
+        @Schema(description = "작가 등록일", example = "2024-01-15T10:30:00")
+        LocalDateTime createdAt
+) {
+    public static ArtistPublicProfileResponse from(ArtistProfile artistProfile) {
+        return new ArtistPublicProfileResponse(
+                artistProfile.getUser().getId(),
+                artistProfile.getArtistName(),
+                artistProfile.getProfileImageUrl(),
+                artistProfile.getDescription(),
+                artistProfile.getMainProducts(),
+                artistProfile.getSnsAccount(),
+                artistProfile.getFollowerCount(),
+                artistProfile.getTotalSales(),
+                artistProfile.getProductCount(),
+                artistProfile.getCreateDate()
+        );
+    }
+}

--- a/src/main/java/com/back/domain/artist/repository/ArtistProfileRepository.java
+++ b/src/main/java/com/back/domain/artist/repository/ArtistProfileRepository.java
@@ -5,6 +5,7 @@ import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ArtistProfileRepository extends JpaRepository<ArtistProfile, Long> {
@@ -24,5 +25,8 @@ public interface ArtistProfileRepository extends JpaRepository<ArtistProfile, Lo
     // User 엔티티를 함께 페치하여 작가 프로필 조회
     @Query("SELECT ap FROM ArtistProfile ap JOIN FETCH ap.user WHERE ap.user.id = :userId")
     Optional<ArtistProfile> findByUserIdWithUser(@Param("userId") Long userId);
+
+    // 모든 작가 목록 조회 (이름순)
+    List<ArtistProfile> findAllByOrderByArtistNameAsc();
 
 }

--- a/src/main/java/com/back/domain/artist/service/ArtistPublicService.java
+++ b/src/main/java/com/back/domain/artist/service/ArtistPublicService.java
@@ -1,0 +1,121 @@
+package com.back.domain.artist.service;
+
+import com.back.domain.artist.dto.response.ArtistListResponse;
+import com.back.domain.artist.dto.response.ArtistProductResponse;
+import com.back.domain.artist.dto.response.ArtistPublicProfileResponse;
+import com.back.domain.artist.entity.ArtistProfile;
+import com.back.domain.artist.repository.ArtistProfileRepository;
+import com.back.domain.product.product.entity.Product;
+import com.back.domain.product.product.entity.ProductImage;
+import com.back.domain.product.product.repository.ProductRepository;
+import com.back.global.exception.ServiceException;
+import com.back.global.s3.FileType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * 작가 공개 정보 조회 서비스
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ArtistPublicService {
+
+    private final ArtistProfileRepository artistProfileRepository;
+    private final ProductRepository productRepository;
+
+    /**
+     * 작가 목록 조회
+     */
+    public List<ArtistListResponse> getArtistList() {
+        log.info("작가 목록 조회 시작 (전체)");
+
+        List<ArtistProfile> artists = artistProfileRepository.findAllByOrderByArtistNameAsc();
+
+        log.info("작가 목록 조회 완료 - 조회된 작가 수: {}", artists.size());
+
+        return artists.stream()
+                .map(ArtistListResponse::from)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 작가 공개 프로필 상세 조회
+     */
+    public ArtistPublicProfileResponse getPublicProfile(Long artistId) {
+        log.info("작가 공개 프로필 조회 시작 - artistId: {}", artistId);
+
+        // 작가 프로필 조회
+        ArtistProfile artistProfile = artistProfileRepository.findByUserId(artistId)
+                .orElseThrow(() -> new ServiceException("404", "존재하지 않는 작가입니다."));
+
+        log.info("작가 공개 프로필 조회 완료 - artistId: {}, artistName: {}",
+                artistId, artistProfile.getArtistName());
+
+        return ArtistPublicProfileResponse.from(artistProfile);
+    }
+
+    /**
+     * 작가 상품 목록 조회
+     */
+    public List<ArtistProductResponse> getArtistProducts(Long artistId, Pageable pageable) {
+        log.info("작가 상품 목록 조회 시작 - artistId: {}, page: {}, size: {}",
+                artistId, pageable.getPageNumber(), pageable.getPageSize());
+
+        // 작가 존재 여부 확인
+        if (!artistProfileRepository.existsByUserId(artistId)) {
+            throw new ServiceException("404", "존재하지 않는 작가입니다.");
+        }
+
+        // 작가의 상품 목록 조회 (판매 중인 상품만)
+        List<Product> products = productRepository.findByUserIdAndIsDeletedFalse(artistId, pageable);
+
+        log.info("작가 상품 목록 조회 완료 - artistId: {}, 조회된 상품 수: {}",
+                artistId, products.size());
+
+        return products.stream()
+                .map(this::convertToArtistProductResponse)
+                .collect(Collectors.toList());
+    }
+
+
+    // ====== 헬퍼 메서드 ====== //
+    /**
+     * Product -> ArtistProductResponse 변환
+     */
+    private ArtistProductResponse convertToArtistProductResponse(Product product) {
+        // 썸네일 이미지 추출
+        String thumbnailUrl = product.getImages().stream()
+                .filter(img -> FileType.THUMBNAIL.equals(img.getFileType()))
+                .findFirst()
+                .map(ProductImage::getFileUrl)
+                .orElse(null);
+
+        // 평균 평점과 리뷰 수 계산
+        // TODO: 실제 리뷰 데이터를 기반으로 계산 로직 구현 필요
+        Double rating = 0.0;
+        Long reviewCount = 0L;
+
+        return new ArtistProductResponse(
+                product.getProductUuid(),
+                product.getName(),
+                product.getPrice(),
+                product.getDiscountPrice(),
+                product.getDiscountRate(),
+                thumbnailUrl,
+                rating,
+                reviewCount,
+                product.getStock(),
+                product.getSellingStatus().name()
+        );
+    }
+
+
+}

--- a/src/main/java/com/back/domain/product/product/repository/ProductRepository.java
+++ b/src/main/java/com/back/domain/product/product/repository/ProductRepository.java
@@ -2,9 +2,11 @@ package com.back.domain.product.product.repository;
 
 import com.back.domain.product.category.entity.Category;
 import com.back.domain.product.product.entity.Product;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -17,4 +19,9 @@ public interface ProductRepository extends JpaRepository<Product, Long>, Product
      * 특정 카테고리의 상품 수 조회
      */
     long countByCategoryAndIsDeletedFalse(Category category);
+
+    /**
+     * 작가의 상품 목록 조회 (삭제되지 않은 상품만)
+     */
+    List<Product> findByUserIdAndIsDeletedFalse(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/back/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/back/global/security/config/SecurityConfig.java
@@ -62,6 +62,9 @@ public class SecurityConfig {
                         // OAuth2 로그인 엔드포인트
                         .requestMatchers("/oauth2/**", "/login/oauth2/**").permitAll()
 
+                        // 작가 공개 정보 조회
+                        .requestMatchers("/api/artist/profile/**", "/api/artist/list").permitAll()
+
                         // 공개 API
                         .requestMatchers("/public/**").permitAll()
 

--- a/src/test/java/com/back/domain/artist/controller/ArtistControllerTest.java
+++ b/src/test/java/com/back/domain/artist/controller/ArtistControllerTest.java
@@ -1,7 +1,9 @@
 package com.back.domain.artist.controller;
 
 import com.back.domain.artist.entity.ArtistApplication;
+import com.back.domain.artist.entity.ArtistProfile;
 import com.back.domain.artist.repository.ArtistApplicationRepository;
+import com.back.domain.artist.repository.ArtistProfileRepository;
 import com.back.domain.user.entity.User;
 import com.back.domain.user.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -37,6 +39,9 @@ class ArtistControllerTest {
 
     @Autowired
     private ArtistApplicationRepository artistApplicationRepository;
+
+    @Autowired
+    private ArtistProfileRepository artistProfileRepository;
 
     @Test
     @WithUserDetails("user2@user.com")
@@ -453,11 +458,11 @@ class ArtistControllerTest {
     }
 
     @Test
-    @WithUserDetails("user2@user.com")
+    @WithUserDetails("artist1@artist.com")
     @DisplayName("15. 작가 사업자 정보 조회 - 성공")
     void t15() throws Exception {
         // given
-        User user = userRepository.findByEmail("user2@user.com").orElseThrow();
+        User user = userRepository.findByEmail("artist1@artist.com").orElseThrow();
         ArtistApplication application = ArtistApplication.builder()
                 .user(user)
                 .artistName("홍길동작가")
@@ -489,6 +494,225 @@ class ArtistControllerTest {
                 .andExpect(jsonPath("$.data.email").value("artist@example.com"))
                 .andExpect(jsonPath("$.data.businessAddress").value("서울시 강남구 테헤란로 123 2층"))
                 .andExpect(jsonPath("$.data.telecomSalesNumber").value("2023-서울강남-0001"));
+    }
+
+    @Test
+    @DisplayName("16. 전체 작가 목록 조회 - 성공")
+    void t16() throws Exception {
+        // given - 작가 프로필 생성 (ArtistApplication 필수)
+        User user1 = userRepository.findByEmail("user1@user.com").orElseThrow();
+        User artist1 = userRepository.findByEmail("artist1@artist.com").orElseThrow();
+
+        // ArtistApplication 먼저 생성
+        ArtistApplication application1 = ArtistApplication.builder()
+                .user(user1)
+                .artistName("유저1작가")
+                .businessName("유저1 작가실")
+                .businessNumber("111-11-11111")
+                .ownerName("유저1")
+                .phone("010-1234-5678")
+                .managerPhone("010-1234-5678")
+                .email("user1@user.com")
+                .businessAddress("서울시 강남구")
+                .businessAddressDetail("1층")
+                .businessZipCode("12345")
+                .telecomSalesNumber("2023-서울강남-0001")
+                .build();
+        artistApplicationRepository.save(application1);
+
+        ArtistApplication application2 = ArtistApplication.builder()
+                .user(artist1)
+                .artistName("작가1")
+                .businessName("작가1 작가실")
+                .businessNumber("222-22-22222")
+                .ownerName("작가1")
+                .phone("010-2111-1111")
+                .managerPhone("010-2111-1111")
+                .email("artist1@artist.com")
+                .businessAddress("서울시 종로구")
+                .businessAddressDetail("2층")
+                .businessZipCode("54321")
+                .telecomSalesNumber("2023-서울종로-0002")
+                .build();
+        artistApplicationRepository.save(application2);
+
+        // ArtistProfile 생성
+        ArtistProfile profile1 = ArtistProfile.builder()
+                .user(user1)
+                .artistApplication(application1)  // ✅ 필수
+                .artistName("유저1작가")
+                .mainProducts("도자기")
+                .build();
+        artistProfileRepository.save(profile1);
+
+        ArtistProfile profile2 = ArtistProfile.builder()
+                .user(artist1)
+                .artistApplication(application2)  // ✅ 필수
+                .artistName("작가1")
+                .mainProducts("회화")
+                .build();
+        artistProfileRepository.save(profile2);
+
+        // when
+        ResultActions resultActions = mvc.perform(get("/api/artist/list")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print());
+
+        // then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value("200"))
+                .andExpect(jsonPath("$.msg").value("작가 목록 조회 성공"))
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data.length()").value(2))
+                .andExpect(jsonPath("$.data[0].artistId").exists())
+                .andExpect(jsonPath("$.data[0].artistName").exists());
+    }
+
+    @Test
+    @DisplayName("17. 전체 작가 목록 조회 - 빈 목록")
+    void t17() throws Exception {
+        // when - ArtistProfile이 없는 상태
+        ResultActions resultActions = mvc.perform(get("/api/artist/list")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print());
+
+        // then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value("200"))
+                .andExpect(jsonPath("$.msg").value("작가 목록 조회 성공"))
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data.length()").value(0));
+    }
+
+    @Test
+    @DisplayName("18. 작가 공개 프로필 조회 - 성공")
+    void t18() throws Exception {
+        // given
+        User user1 = userRepository.findByEmail("user1@user.com").orElseThrow();
+
+        // ArtistApplication 먼저 생성
+        ArtistApplication application = ArtistApplication.builder()
+                .user(user1)
+                .artistName("유저1작가")
+                .businessName("유저1 작가실")
+                .businessNumber("111-11-11111")
+                .ownerName("유저1")
+                .phone("010-1234-5678")
+                .managerPhone("010-1234-5678")
+                .email("user1@user.com")
+                .businessAddress("서울시 강남구")
+                .businessAddressDetail("1층")
+                .businessZipCode("12345")
+                .telecomSalesNumber("2023-서울강남-0001")
+                .build();
+        artistApplicationRepository.save(application);
+
+        // ArtistProfile 생성
+        ArtistProfile profile = ArtistProfile.builder()
+                .user(user1)
+                .artistApplication(application)  // ✅ 필수
+                .artistName("유저1작가")
+                .description("전통 도자기를 현대적으로 재해석하는 작가입니다.")
+                .mainProducts("도자기, 머그컵")
+                .snsAccount("@artist_user1")
+                .profileImageUrl("https://example.com/profile.jpg")
+                .build();
+        artistProfileRepository.save(profile);
+
+        // when
+        ResultActions resultActions = mvc.perform(get("/api/artist/profile/" + user1.getId())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print());
+
+        // then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value("200"))
+                .andExpect(jsonPath("$.msg").value("작가 프로필 조회 성공"))
+                .andExpect(jsonPath("$.data.artistId").value(user1.getId()))
+                .andExpect(jsonPath("$.data.artistName").value("유저1작가"))
+                .andExpect(jsonPath("$.data.description").value("전통 도자기를 현대적으로 재해석하는 작가입니다."))
+                .andExpect(jsonPath("$.data.mainProducts").value("도자기, 머그컵"))
+                .andExpect(jsonPath("$.data.snsAccount").value("@artist_user1"))
+                .andExpect(jsonPath("$.data.followerCount").value(0))
+                .andExpect(jsonPath("$.data.totalSales").value(0))
+                .andExpect(jsonPath("$.data.productCount").value(0))
+                .andExpect(jsonPath("$.data.createdAt").exists());
+    }
+
+    @Test
+    @DisplayName("19. 작가 공개 프로필 조회 - 실패 (존재하지 않는 작가)")
+    void t19() throws Exception {
+        // when
+        ResultActions resultActions = mvc.perform(get("/api/artist/profile/99999")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print());
+
+        // then
+        resultActions.andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.resultCode").value("404"))
+                .andExpect(jsonPath("$.msg").value("존재하지 않는 작가입니다."));
+    }
+
+    @Test
+    @DisplayName("20. 작가 상품 목록 조회 - 성공 (상품 없음)")
+    void t20() throws Exception {
+        // given
+        User user1 = userRepository.findByEmail("user1@user.com").orElseThrow();
+
+        // ArtistApplication 먼저 생성
+        ArtistApplication application = ArtistApplication.builder()
+                .user(user1)
+                .artistName("유저1작가")
+                .businessName("유저1 작가실")
+                .businessNumber("111-11-11111")
+                .ownerName("유저1")
+                .phone("010-1234-5678")
+                .managerPhone("010-1234-5678")
+                .email("user1@user.com")
+                .businessAddress("서울시 강남구")
+                .businessAddressDetail("1층")
+                .businessZipCode("12345")
+                .telecomSalesNumber("2023-서울강남-0001")
+                .build();
+        artistApplicationRepository.save(application);
+
+        // ArtistProfile 생성
+        ArtistProfile profile = ArtistProfile.builder()
+                .user(user1)
+                .artistApplication(application)  // ✅ 필수
+                .artistName("유저1작가")
+                .build();
+        artistProfileRepository.save(profile);
+
+        // when - 상품이 없는 상태에서 조회
+        ResultActions resultActions = mvc.perform(get("/api/artist/profile/" + user1.getId() + "/products")
+                        .param("page", "1")
+                        .param("size", "12")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print());
+
+        // then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value("200"))
+                .andExpect(jsonPath("$.msg").value("작가 상품 목록 조회 성공"))
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data.length()").value(0));
+    }
+
+    @Test
+    @DisplayName("21. 작가 상품 목록 조회 - 실패 (존재하지 않는 작가)")
+    void t21() throws Exception {
+        // when
+        ResultActions resultActions = mvc.perform(get("/api/artist/profile/99999/products")
+                        .param("page", "1")
+                        .param("size", "12")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print());
+
+        // then
+        resultActions.andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.resultCode").value("404"))
+                .andExpect(jsonPath("$.msg").value("존재하지 않는 작가입니다."));
     }
 
 }

--- a/src/test/java/com/back/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/back/domain/auth/service/AuthServiceTest.java
@@ -179,7 +179,7 @@ class AuthServiceTest {
                     .satisfies(ex -> {
                         ServiceException serviceEx = (ServiceException) ex;
                         assertThat(serviceEx.getResultCode()).isEqualTo("401");
-                        assertThat(serviceEx.getMsg()).isEqualTo("이메일 또는 비밀번호가 잘못되었습니다.");
+                        assertThat(serviceEx.getMsg()).isEqualTo("이메일이 잘못되었습니다.");
                     });
         }
 
@@ -200,7 +200,7 @@ class AuthServiceTest {
                     .satisfies(ex -> {
                         ServiceException serviceEx = (ServiceException) ex;
                         assertThat(serviceEx.getResultCode()).isEqualTo("401");
-                        assertThat(serviceEx.getMsg()).isEqualTo("이메일 또는 비밀번호가 잘못되었습니다.");
+                        assertThat(serviceEx.getMsg()).isEqualTo("비밀번호가 잘못되었습니다.");
                     });
         }
     }


### PR DESCRIPTION
## 📢 기능 설명

### 생성된 파일
- DTO
   - ArtistListResponse - 전체 작가 목록 응답(ID, 이름만)
   - ArtistProductResponse - 작가 상품 정보 응답
   - ArtistPublicProfileResponse - 작가 공개 프로필 응답
- Service
   - ArtistPublicService - 작가 공개 정보 조회 서비스

### 수정된 파일
- ArtistController (API 3개 추가)
   - GET /api/artist/list - 전체 작가 목록 조회
   - GET /api/artist/profile/{id} - 작가 프로필 상세 조회
   - GET /api/artist/profile/{id}/products - 작가 상품 목록 조회
- ArtistProfileRespository - 작가 조회 메서드 추가
- ProductRepository - 작가별 상품 조회 메서드 추가
- SecurityConfig - 작가 공개 API 권한 설정
- Test코드
   - 추가된 API 테스트 성공/실패 케이스 추가
   - 로그인 실패 메시지 변경에 따른 메시지 수정


## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #242
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?
