### PR TITLE
[feat] 공지사항 기능 구현

### DIFF
--- a/src/main/java/com/back/domain/notice/controller/NoticeController.java
+++ b/src/main/java/com/back/domain/notice/controller/NoticeController.java
@@ -1,0 +1,161 @@
+package com.back.domain.notice.controller;
+
+import com.back.domain.notice.dto.request.NoticeCreateRequest;
+import com.back.domain.notice.dto.request.NoticeUpdateRequest;
+import com.back.domain.notice.dto.response.NoticeDetailResponse;
+import com.back.domain.notice.dto.response.NoticeListResponse;
+import com.back.domain.notice.service.NoticeService;
+import com.back.global.rsData.RsData;
+import com.back.global.security.auth.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+@Slf4j
+@RestController
+@RequestMapping("/api/notices")
+@RequiredArgsConstructor
+@Tag(name = "공지사항", description = "공지사항 관련 API")
+public class NoticeController {
+
+    private final NoticeService noticeService;
+
+    /**
+     * 공지사항 목록 조회
+     */
+    @GetMapping
+    @Operation(
+            summary = "공지사항 목록 조회",
+            description = "공지사항 목록을 페이징하여 조회합니다. 검색 키워드를 입력하면 제목/내용 검색이 가능합니다."
+    )
+    public ResponseEntity<RsData<NoticeListResponse>> getNotices(
+            @Parameter(description = "검색 키워드 (제목 또는 내용)", example = "배송")
+            @RequestParam(required = false) String keyword,
+
+            @Parameter(description = "페이지 번호 (1부터 시작)", example = "1")
+            @RequestParam(defaultValue = "1") int page,
+
+            @Parameter(description = "페이지 크기", example = "10")
+            @RequestParam(defaultValue = "10") int size) {
+
+        log.info("공지사항 목록 조회 - keyword: {}, page: {}, size: {}", keyword, page, size);
+
+        // 프론트는 1부터 시작 -> Spring Pageable은 0부터 시작하므로 -1 처리
+        Pageable pageable = PageRequest.of(page - 1, size);
+
+        NoticeListResponse response = noticeService.getNotices(keyword, pageable);
+
+        return ResponseEntity.ok(
+                RsData.of("200", "공지사항 목록 조회 성공", response)
+        );
+    }
+
+    /**
+     * 공지사항 상세 조회
+     */
+    @GetMapping("/{noticeId}")
+    @Operation(
+            summary = "공지사항 상세 조회",
+            description = "공지사항 상세 정보를 조회합니다. 조회 시 조회수가 1 증가합니다."
+    )
+    public ResponseEntity<RsData<NoticeDetailResponse>> getNotice(
+            @Parameter(description = "공지사항 ID", example = "1", required = true)
+            @PathVariable Long noticeId) {
+
+        log.info("공지사항 상세 조회 - noticeId: {}", noticeId);
+
+        NoticeDetailResponse response = noticeService.getNotice(noticeId);
+
+        return ResponseEntity.ok(
+                RsData.of("200", "공지사항 상세 조회 성공", response)
+        );
+    }
+
+
+    // ========================================
+    // 관리자 전용 API
+    // ========================================
+
+    /**
+     * 공지사항 생성
+     */
+    @PostMapping
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(
+            summary = "공지사항 생성 (관리자 전용)",
+            description = "새로운 공지사항을 생성합니다. 첨부파일은 최대 5개까지 업로드 가능합니다."
+    )
+    public ResponseEntity<RsData<Long>> createNotice(
+            @Valid @ModelAttribute NoticeCreateRequest request,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails adminUser) {
+
+        log.info("공지사항 생성 요청 - adminId: {}, title: {}", adminUser.getUserId(), request.title());
+
+        Long noticeId = noticeService.createNotice(request);
+
+        return ResponseEntity.ok(
+                RsData.of("200", "공지사항이 성공적으로 등록되었습니다.", noticeId)
+        );
+    }
+
+    /**
+     * 공지사항 수정
+     */
+    @PutMapping("/{noticeId}")
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(
+            summary = "공지사항 수정 (관리자 전용)",
+            description = "공지사항을 수정합니다. 기존 첨부파일 삭제 및 새 첨부파일 추가가 가능합니다."
+    )
+    public ResponseEntity<RsData<Void>> updateNotice(
+            @Parameter(description = "공지사항 ID", example = "1", required = true)
+            @PathVariable Long noticeId,
+
+            @Valid @ModelAttribute NoticeUpdateRequest request,
+
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal CustomUserDetails adminUser) {
+
+        log.info("공지사항 수정 요청 - adminId: {}, noticeId: {}", adminUser.getUserId(), noticeId);
+
+        noticeService.updateNotice(noticeId, request);
+
+        return ResponseEntity.ok(
+                RsData.of("200", "공지사항이 성공적으로 수정되었습니다.")
+        );
+    }
+
+    /**
+     * 공지사항 삭제
+     */
+    @DeleteMapping("/{noticeId}")
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(
+            summary = "공지사항 삭제 (관리자 전용)",
+            description = "공지사항을 삭제합니다. 첨부파일도 함께 삭제됩니다."
+    )
+    public ResponseEntity<RsData<Void>> deleteNotice(
+            @Parameter(description = "공지사항 ID", example = "1", required = true)
+            @PathVariable Long noticeId,
+
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal CustomUserDetails adminUser) {
+
+        log.info("공지사항 삭제 요청 - adminId: {}, noticeId: {}", adminUser.getUserId(), noticeId);
+
+        noticeService.deleteNotice(noticeId);
+
+        return ResponseEntity.ok(
+                RsData.of("200", "공지사항이 삭제되었습니다.")
+        );
+    }
+
+}

--- a/src/main/java/com/back/domain/notice/dto/request/NoticeCreateRequest.java
+++ b/src/main/java/com/back/domain/notice/dto/request/NoticeCreateRequest.java
@@ -1,0 +1,39 @@
+package com.back.domain.notice.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+/**
+ * 공지사항 생성 요청 DTO
+ */
+@Schema(description = "공지사항 생성 요청")
+public record NoticeCreateRequest(
+
+        @Schema(description = "공지사항 제목", example = "2024년 설날 연휴 배송 안내")
+        @NotBlank(message = "제목은 필수입니다")
+        @Size(max = 200, message = "제목은 200자를 초과할 수 없습니다")
+        String title,
+
+        @Schema(description = "공지사항 내용", example = "설날 연휴 기간에는 배송이 지연될 수 있습니다.")
+        @NotBlank(message = "내용은 필수입니다")
+        String content,
+
+        @Schema(description = "중요 공지 여부", example = "true")
+        Boolean isImportant,
+
+        @Schema(description = "첨부파일 목록 (최대 5개)")
+        List<MultipartFile> files
+) {
+    /**
+     * 기본값 설정 생성자
+     */
+    public NoticeCreateRequest {
+        if (isImportant == null) {
+            isImportant = false;
+        }
+    }
+}

--- a/src/main/java/com/back/domain/notice/dto/request/NoticeUpdateRequest.java
+++ b/src/main/java/com/back/domain/notice/dto/request/NoticeUpdateRequest.java
@@ -1,0 +1,42 @@
+package com.back.domain.notice.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+/**
+ * 공지사항 수정 요청 DTO
+ */
+@Schema(description = "공지사항 수정 요청")
+public record NoticeUpdateRequest(
+
+        @Schema(description = "공지사항 제목", example = "2024년 설날 연휴 배송 안내 (수정)")
+        @NotBlank(message = "제목은 필수입니다")
+        @Size(max = 200, message = "제목은 200자를 초과할 수 없습니다")
+        String title,
+
+        @Schema(description = "공지사항 내용", example = "수정된 내용입니다.")
+        @NotBlank(message = "내용은 필수입니다")
+        String content,
+
+        @Schema(description = "중요 공지 여부", example = "false")
+        Boolean isImportant,
+
+        @Schema(description = "새로 추가할 첨부파일 목록")
+        List<MultipartFile> files,
+
+        @Schema(description = "삭제할 기존 첨부파일 ID 목록", example = "[1, 2, 3]")
+        List<Long> deleteFileIds
+) {
+    /**
+     * 기본값 설정 생성자
+     */
+    public NoticeUpdateRequest {
+        if (isImportant == null) {
+            isImportant = false;
+        }
+    }
+}

--- a/src/main/java/com/back/domain/notice/dto/response/NoticeDetailResponse.java
+++ b/src/main/java/com/back/domain/notice/dto/response/NoticeDetailResponse.java
@@ -1,0 +1,81 @@
+package com.back.domain.notice.dto.response;
+
+import com.back.domain.notice.entity.Notice;
+import com.back.domain.notice.entity.NoticeDocument;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * 공지사항 상세 조회 응답 DTO
+ */
+@Schema(description = "공지사항 상세 조회 응답")
+public record NoticeDetailResponse(
+
+        @Schema(description = "공지사항 ID", example = "1")
+        Long id,
+
+        @Schema(description = "제목", example = "2024년 설날 연휴 배송 안내")
+        String title,
+
+        @Schema(description = "내용", example = "설날 연휴 기간에는 배송이 지연될 수 있습니다.")
+        String content,
+
+        @Schema(description = "중요 공지 여부", example = "true")
+        Boolean isImportant,
+
+        @Schema(description = "조회수", example = "150")
+        Long viewCount,
+
+        @Schema(description = "첨부파일 목록")
+        List<NoticeDocumentDto> documents,
+
+        @Schema(description = "작성일시", example = "2024-01-15T10:30:00")
+        LocalDateTime createDate,
+
+        @Schema(description = "수정일시", example = "2024-01-16T14:20:00")
+        LocalDateTime modifyDate
+) {
+    /**
+     * Entity -> DTO 변환
+     */
+    public static NoticeDetailResponse from(Notice notice) {
+        return new NoticeDetailResponse(
+                notice.getId(),
+                notice.getTitle(),
+                notice.getContent(),
+                notice.getIsImportant(),
+                notice.getViewCount(),
+                notice.getDocuments().stream()
+                        .map(NoticeDocumentDto::from)
+                        .collect(Collectors.toList()),
+                notice.getCreateDate(),
+                notice.getModifyDate()
+        );
+    }
+
+    /**
+     * 첨부파일 정보 DTO
+     */
+    @Schema(description = "공지사항 첨부파일 정보")
+    public record NoticeDocumentDto(
+            @Schema(description = "첨부파일 ID", example = "1")
+            Long id,
+
+            @Schema(description = "파일명", example = "공지사항_첨부파일.pdf")
+            String fileName,
+
+            @Schema(description = "파일 URL", example = "https://s3.amazonaws.com/bucket/notice/file.pdf")
+            String fileUrl
+    ) {
+        public static NoticeDocumentDto from(NoticeDocument document) {
+            return new NoticeDocumentDto(
+                    document.getId(),
+                    document.getFileName(),
+                    document.getFileUrl()
+            );
+        }
+    }
+}

--- a/src/main/java/com/back/domain/notice/dto/response/NoticeListResponse.java
+++ b/src/main/java/com/back/domain/notice/dto/response/NoticeListResponse.java
@@ -1,0 +1,86 @@
+package com.back.domain.notice.dto.response;
+
+import com.back.domain.notice.entity.Notice;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.springframework.data.domain.Page;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+/**
+ * 공지사항 목록 조회 응답 DTO
+ */
+@Schema(description = "공지사항 목록 조회 응답")
+public record NoticeListResponse(
+
+        @Schema(description = "공지사항 목록")
+        List<NoticeItemDto> notices,
+
+        @Schema(description = "현재 페이지 번호 (0부터 시작)", example = "0")
+        int currentPage,
+
+        @Schema(description = "페이지 크기", example = "10")
+        int pageSize,
+
+        @Schema(description = "전체 공지사항 개수", example = "50")
+        long totalElements,
+
+        @Schema(description = "전체 페이지 수", example = "5")
+        int totalPages,
+
+        @Schema(description = "마지막 페이지 여부", example = "false")
+        boolean isLast
+) {
+    /**
+     * Page<Notice> -> NoticeListResponse 변환
+     */
+    public static NoticeListResponse from(Page<Notice> noticePage) {
+        List<NoticeItemDto> noticeItems = noticePage.getContent().stream()
+                .map(NoticeItemDto::from)
+                .collect(Collectors.toList());
+
+        return new NoticeListResponse(
+                noticeItems,
+                noticePage.getNumber(),
+                noticePage.getSize(),
+                noticePage.getTotalElements(),
+                noticePage.getTotalPages(),
+                noticePage.isLast()
+        );
+    }
+
+    /**
+     * 공지사항 목록 아이템 DTO
+     */
+    @Schema(description = "공지사항 목록 아이템")
+    public record NoticeItemDto(
+            @Schema(description = "공지사항 ID", example = "1")
+            Long id,
+
+            @Schema(description = "제목", example = "2024년 설날 연휴 배송 안내")
+            String title,
+
+            @Schema(description = "중요 공지 여부", example = "true")
+            Boolean isImportant,
+
+            @Schema(description = "조회수", example = "150")
+            Long viewCount,
+
+            @Schema(description = "첨부파일 개수", example = "2")
+            int documentCount,
+
+            @Schema(description = "작성일시", example = "2024-01-15T10:30:00")
+            LocalDateTime createDate
+    ) {
+        public static NoticeItemDto from(Notice notice) {
+            return new NoticeItemDto(
+                    notice.getId(),
+                    notice.getTitle(),
+                    notice.getIsImportant(),
+                    notice.getViewCount(),
+                    notice.getDocuments().size(),
+                    notice.getCreateDate()
+            );
+        }
+    }
+}

--- a/src/main/java/com/back/domain/notice/entity/Notice.java
+++ b/src/main/java/com/back/domain/notice/entity/Notice.java
@@ -1,0 +1,77 @@
+package com.back.domain.notice.entity;
+
+import com.back.global.jpa.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 공지사항 엔티티
+ */
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "notices")
+public class Notice extends BaseEntity {
+
+    @Column(nullable = false, length = 200)
+    private String title;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(nullable = false)
+    private Boolean isImportant = false; // 공지사항 중요 여부
+
+    @Column(nullable = false)
+    private Long viewCount = 0L;
+
+    @OneToMany(mappedBy = "notice", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<NoticeDocument> documents = new ArrayList<>(); // 공지사항 첨부파일 목록
+
+    @Builder
+    public Notice(String title, String content, Boolean isImportant) {
+        this.title = title;
+        this.content = content;
+        this.isImportant = isImportant != null ? isImportant : false;
+        this.viewCount = 0L;
+    }
+
+    // ==== 비즈니스 로직 ==== //
+
+    /**
+     * 공지사항 수정
+     */
+    public void update(String title, String content, Boolean isImportant) {
+        if (title != null) this.title = title;
+        if (content != null) this.content = content;
+        if (isImportant != null) this.isImportant = isImportant;
+    }
+
+    /**
+     * 조회수 증가
+     */
+    public void increaseViewCount() {
+        this.viewCount++;
+    }
+
+    /**
+     * 첨부파일 추가
+     */
+    public void addDocument(NoticeDocument document) {
+        this.documents.add(document);
+        document.setNotice(this);
+    }
+
+    /**
+     * 첨부파일 전체 삭제
+     */
+    public void clearAttachments() {
+        this.documents.clear();
+    }
+}

--- a/src/main/java/com/back/domain/notice/entity/NoticeDocument.java
+++ b/src/main/java/com/back/domain/notice/entity/NoticeDocument.java
@@ -1,0 +1,70 @@
+package com.back.domain.notice.entity;
+
+import com.back.global.jpa.entity.BaseEntity;
+import com.back.global.s3.S3FileRequest;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 공지사항 첨부파일 엔티티
+ */
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "notice_documents")
+public class NoticeDocument extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "notice_id", nullable = false)
+    private Notice notice;
+
+    @Column(nullable = false, length = 255)
+    private String fileName;
+
+    @Column(nullable = false, length = 500)
+    private String fileUrl; // S3 URL
+
+    @Column(nullable = false, length = 500)
+    private String s3Key; // S3 Key
+
+    @Builder
+    public NoticeDocument(Notice notice, String fileName, String fileUrl, String s3Key) {
+        this.notice = notice;
+        this.fileName = fileName;
+        this.fileUrl = fileUrl;
+        this.s3Key = s3Key;
+    }
+
+    /**
+     * S3FileRequest로부터 NoticeDocument 엔티티 생성
+     * @param notice 공지사항
+     * @param s3FileRequest S3 파일 업로드 정보
+     * @return 생성된 NoticeDocument 엔티티
+     */
+    public static NoticeDocument fromS3FileRequest(Notice notice, S3FileRequest s3FileRequest) {
+        return NoticeDocument.builder()
+                .notice(notice)
+                .fileName(s3FileRequest.originalFileName())
+                .fileUrl(s3FileRequest.url())
+                .s3Key(s3FileRequest.s3Key())
+                .build();
+    }
+
+    /**
+     * 공지사항 설정 (양방향 관계)
+     */
+    void setNotice(Notice notice) {
+        this.notice = notice;
+    }
+
+    /**
+     * 첨부파일이 특정 공지사항에 속하는지 확인
+     */
+    public boolean belongsTo(Long noticeId) {
+        return this.notice.getId().equals(noticeId);
+    }
+
+}

--- a/src/main/java/com/back/domain/notice/repository/NoticeDocumentRepository.java
+++ b/src/main/java/com/back/domain/notice/repository/NoticeDocumentRepository.java
@@ -1,0 +1,23 @@
+package com.back.domain.notice.repository;
+
+import com.back.domain.notice.entity.NoticeDocument;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface NoticeDocumentRepository extends JpaRepository<NoticeDocument, Long> {
+
+    // 공지사항 ID로 첨부파일 목록 조회
+    List<NoticeDocument> findByNoticeId(Long noticeId);
+
+    // 공지사항 ID로 첨부파일 삭제
+    @Modifying
+    @Query("DELETE FROM NoticeDocument d WHERE d.notice.id = :noticeId")
+    void deleteByNoticeId(@Param("noticeId") Long noticeId);
+
+    // S3 Key로 첨부파일 조회
+    List<NoticeDocument> findByS3Key(String s3Key);
+}

--- a/src/main/java/com/back/domain/notice/repository/NoticeRepository.java
+++ b/src/main/java/com/back/domain/notice/repository/NoticeRepository.java
@@ -1,0 +1,25 @@
+package com.back.domain.notice.repository;
+
+import com.back.domain.notice.entity.Notice;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface NoticeRepository extends JpaRepository<Notice, Long> {
+
+    // 전체 공지사항 페이징 조회 (중요공지 먼저, 최신순)
+    Page<Notice> findAllByOrderByIsImportantDescCreateDateDesc(Pageable pageable);
+
+    // 키워드로 공지사항 검색 (제목, 내용) - 중요공지 먼저, 최신순
+    @Query("SELECT n FROM Notice n WHERE n.title LIKE %:keyword% OR n.content LIKE %:keyword% " +
+            "ORDER BY n.isImportant DESC, n.createDate DESC")
+    Page<Notice> searchByKeyword(@Param("keyword") String keyword, Pageable pageable);
+
+    // 공지사항 상세 조회 (첨부파일 포함)
+    @Query("SELECT n FROM Notice n LEFT JOIN FETCH n.documents WHERE n.id = :id")
+    Optional<Notice> findByIdWithDocuments(@Param("id") Long id);
+}

--- a/src/main/java/com/back/domain/notice/service/NoticeService.java
+++ b/src/main/java/com/back/domain/notice/service/NoticeService.java
@@ -1,0 +1,208 @@
+package com.back.domain.notice.service;
+
+import com.back.domain.notice.dto.request.NoticeCreateRequest;
+import com.back.domain.notice.dto.request.NoticeUpdateRequest;
+import com.back.domain.notice.dto.response.NoticeDetailResponse;
+import com.back.domain.notice.dto.response.NoticeListResponse;
+import com.back.domain.notice.entity.Notice;
+import com.back.domain.notice.entity.NoticeDocument;
+import com.back.domain.notice.repository.NoticeDocumentRepository;
+import com.back.domain.notice.repository.NoticeRepository;
+import com.back.global.exception.ServiceException;
+import com.back.global.s3.FileType;
+import com.back.global.s3.S3Service;
+import com.back.global.s3.UploadResultResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 공지사항 서비스
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NoticeService {
+
+    private final NoticeRepository noticeRepository;
+    private final NoticeDocumentRepository noticeDocumentRepository;
+    private final S3Service s3Service;
+
+    /**
+     * 공지사항 생성
+     */
+    public Long createNotice(NoticeCreateRequest request) {
+        // 1. 공지사항 엔티티 생성
+        Notice notice = Notice.builder()
+                .title(request.title())
+                .content(request.content())
+                .isImportant(request.isImportant())
+                .build();
+
+        // 2. 공지사항 저장
+        Notice savedNotice = noticeRepository.save(notice);
+
+        // 3. 첨부파일 처리
+        if (request.files() != null && !request.files().isEmpty()) {
+            uploadAndSaveDocuments(savedNotice, request.files());
+        }
+
+        log.info("공지사항 생성 완료 - noticeId: {}", savedNotice.getId());
+        return savedNotice.getId();
+    }
+
+    /**
+     * 공지사항 목록 조회
+     */
+    public NoticeListResponse getNotices(String keyword, Pageable pageable) {
+        log.info("공지사항 목록 조회 - keyword: {}, page: {}, size: {}",
+                keyword, pageable.getPageNumber(), pageable.getPageSize());
+
+        Page<Notice> noticePage;
+
+        if (keyword != null && !keyword.trim().isEmpty()) {
+            // 검색어가 있으면 검색
+            noticePage = noticeRepository.searchByKeyword(keyword, pageable);
+        } else {
+            // 전체 조회
+            noticePage = noticeRepository.findAllByOrderByIsImportantDescCreateDateDesc(pageable);
+        }
+
+        return NoticeListResponse.from(noticePage);
+    }
+
+    /**
+     * 공지사항 상세 조회
+     */
+    @Transactional
+    public NoticeDetailResponse getNotice(Long noticeId) {
+        log.info("공지사항 상세 조회 - noticeId: {}", noticeId);
+
+        Notice notice = noticeRepository.findByIdWithDocuments(noticeId)
+                .orElseThrow(() -> new ServiceException("404", "존재하지 않는 공지사항입니다."));
+
+        // 조회수 증가
+        notice.increaseViewCount();
+
+        return NoticeDetailResponse.from(notice);
+    }
+
+    /**
+     * 공지사항 수정
+     */
+    @Transactional
+    public void updateNotice(Long noticeId, NoticeUpdateRequest request) {
+
+        // 1. 공지사항 조회
+        Notice notice = noticeRepository.findByIdWithDocuments(noticeId)
+                .orElseThrow(() -> new ServiceException("404", "존재하지 않는 공지사항입니다."));
+
+        // 2. 기본 정보 수정
+        notice.update(request.title(), request.content(), request.isImportant());
+
+        // 3. 기존 첨부파일 삭제 처리
+        if (request.deleteFileIds() != null && !request.deleteFileIds().isEmpty()) {
+            deleteDocuments(notice, request.deleteFileIds());
+        }
+
+        // 4. 새 첨부파일 업로드 및 저장
+        if (request.files() != null && !request.files().isEmpty()) {
+            uploadAndSaveDocuments(notice, request.files());
+        }
+
+        log.info("공지사항 수정 완료 - noticeId: {}", noticeId);
+    }
+
+    /**
+     * 공지사항 삭제
+     */
+    @Transactional
+    public void deleteNotice(Long noticeId) {
+        // 1. 공지사항 조회
+        Notice notice = noticeRepository.findByIdWithDocuments(noticeId)
+                .orElseThrow(() -> new ServiceException("404", "존재하지 않는 공지사항입니다."));
+
+        // 2. S3에서 첨부파일 삭제
+        for (NoticeDocument document : notice.getDocuments()) {
+            try {
+                s3Service.deleteFile(document.getS3Key());
+                log.info("S3 파일 삭제 완료 - s3Key: {}", document.getS3Key());
+            } catch (Exception e) {
+                log.error("S3 파일 삭제 실패 - s3Key: {}, error: {}", document.getS3Key(), e.getMessage());
+            }
+        }
+
+        // 3. 공지사항 삭제 (첨부파일도 자동 삭제 - orphanRemoval = true)
+        noticeRepository.delete(notice);
+
+        log.info("공지사항 삭제 완료 - noticeId: {}", noticeId);
+    }
+
+    // ===== 헬퍼 메서드 ===== //
+
+    /**
+     * 첨부파일 업로드 및 DB 저장
+     */
+    private void uploadAndSaveDocuments(Notice notice, List<MultipartFile> files) {
+        // 파일 타입 리스트 생성 (모두 DOCUMENT 타입)
+        List<FileType> fileTypes = new ArrayList<>();
+        for (int i = 0; i < files.size(); i++) {
+            fileTypes.add(FileType.DOCUMENT);
+        }
+
+        // S3 업로드
+        List<UploadResultResponse> uploadResults = s3Service.uploadFiles(files, "notice-documents", fileTypes);
+
+        // DB 저장
+        for (int i = 0; i < uploadResults.size(); i++) {
+            UploadResultResponse result = uploadResults.get(i);
+            MultipartFile file = files.get(i);
+
+            NoticeDocument document = NoticeDocument.builder()
+                    .notice(notice)
+                    .fileName(result.originalFileName())
+                    .fileUrl(result.url())
+                    .s3Key(result.s3Key())
+                    .build();
+
+            notice.addDocument(document);
+            log.info("첨부파일 저장 완료 - fileName: {}", document.getFileName());
+        }
+    }
+
+    /**
+     * 첨부파일 삭제
+     */
+    private void deleteDocuments(Notice notice, List<Long> deleteFileIds) {
+        for (Long fileId : deleteFileIds) {
+            NoticeDocument document = noticeDocumentRepository.findById(fileId)
+                    .orElseThrow(() -> new ServiceException("404", "존재하지 않는 첨부파일입니다."));
+
+            // 권한 확인 (해당 공지사항의 첨부파일인지)
+            if (!document.belongsTo(notice.getId())) {
+                throw new ServiceException("403", "해당 공지사항의 첨부파일이 아닙니다.");
+            }
+
+            // S3에서 삭제
+            try {
+                s3Service.deleteFile(document.getS3Key());
+                log.info("S3 파일 삭제 완료 - s3Key: {}", document.getS3Key());
+            } catch (Exception e) {
+                log.error("S3 파일 삭제 실패 - s3Key: {}, error: {}", document.getS3Key(), e.getMessage());
+            }
+
+            // DB에서 삭제
+            notice.getDocuments().remove(document);
+            noticeDocumentRepository.delete(document);
+        }
+    }
+
+}

--- a/src/main/java/com/back/global/initData/ProdInitData.java
+++ b/src/main/java/com/back/global/initData/ProdInitData.java
@@ -30,16 +30,16 @@ public class ProdInitData {
     private final PasswordEncoder passwordEncoder;
     private final ArtistApplicationRepository artistApplicationRepository;
 
-    @Value("${init.admin.email}")
+    @Value("${INIT_ADMIN_EMAIL}")
     private String adminEmail;
 
-    @Value("${init.admin.password}")
+    @Value("${INIT_ADMIN_PASSWORD}")
     private String adminPassword;
 
-    @Value("${init.artist.email}")
+    @Value("${INIT_ARTIST_EMAIL}")
     private String artistEmail;
 
-    @Value("${init.artist.password}")
+    @Value("${INIT_ARTIST_PASSWORD}")
     private String artistPassword;
 
     @Bean

--- a/src/main/java/com/back/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/back/global/security/config/SecurityConfig.java
@@ -65,6 +65,11 @@ public class SecurityConfig {
                         // 작가 공개 정보 조회
                         .requestMatchers("/api/artist/profile/**", "/api/artist/list").permitAll()
 
+                        // 공지사항 조회 - 로그인 없이 접근 허용
+                        .requestMatchers(HttpMethod.GET, "/api/notices", "/api/notices/**").permitAll()
+                        // 공지사항 생성, 수정, 삭제 - ADMIN, ROOT만 접근 가능
+                        .requestMatchers("/api/notices", "/api/notices/**").hasAnyRole("ADMIN", "ROOT")
+
                         // 공개 API
                         .requestMatchers("/public/**").permitAll()
 

--- a/src/test/java/com/back/domain/notice/controller/NoticeControllerTest.java
+++ b/src/test/java/com/back/domain/notice/controller/NoticeControllerTest.java
@@ -1,0 +1,374 @@
+package com.back.domain.notice.controller;
+
+import com.back.domain.notice.entity.Notice;
+import com.back.domain.notice.repository.NoticeDocumentRepository;
+import com.back.domain.notice.repository.NoticeRepository;
+import com.back.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithUserDetails;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@ActiveProfiles("test")
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@DisplayName("공지사항 컨트롤러 테스트")
+public class NoticeControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private NoticeRepository noticeRepository;
+
+    @Autowired
+    private NoticeDocumentRepository noticeDocumentRepository;
+
+    @Test
+    @DisplayName("1. 공지사항 목록 조회 - 성공")
+    void t1() throws Exception {
+        // given - 공지사항 생성
+        Notice notice1 = Notice.builder()
+                .title("설날 연휴 배송 안내")
+                .content("설날 연휴 기간에는 배송이 지연될 수 있습니다.")
+                .isImportant(true)
+                .build();
+        noticeRepository.save(notice1);
+
+        Notice notice2 = Notice.builder()
+                .title("신규 작가 입점 안내")
+                .content("새로운 작가님들이 입점했습니다.")
+                .isImportant(false)
+                .build();
+        noticeRepository.save(notice2);
+
+        // when
+        ResultActions resultActions = mvc.perform(get("/api/notices")
+                        .param("page", "1")
+                        .param("size", "10")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print());
+
+        // then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value("200"))
+                .andExpect(jsonPath("$.msg").value("공지사항 목록 조회 성공"))
+                .andExpect(jsonPath("$.data.notices").isArray())
+                .andExpect(jsonPath("$.data.notices.length()").value(2))
+                .andExpect(jsonPath("$.data.currentPage").value(0))
+                .andExpect(jsonPath("$.data.totalElements").value(2));
+    }
+
+    @Test
+    @DisplayName("2. 공지사항 목록 조회 - 빈 목록")
+    void t2() throws Exception {
+        // when
+        ResultActions resultActions = mvc.perform(get("/api/notices")
+                        .param("page", "1")
+                        .param("size", "10")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print());
+
+        // then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value("200"))
+                .andExpect(jsonPath("$.msg").value("공지사항 목록 조회 성공"))
+                .andExpect(jsonPath("$.data.notices").isArray())
+                .andExpect(jsonPath("$.data.notices.length()").value(0));
+    }
+
+    @Test
+    @DisplayName("3. 공지사항 검색 - 성공")
+    void t3() throws Exception {
+        // given
+        Notice notice1 = Notice.builder()
+                .title("배송 관련 공지")
+                .content("배송이 지연됩니다.")
+                .isImportant(false)
+                .build();
+        noticeRepository.save(notice1);
+
+        Notice notice2 = Notice.builder()
+                .title("작가 입점 안내")
+                .content("새로운 작가님들이 입점했습니다.")
+                .isImportant(false)
+                .build();
+        noticeRepository.save(notice2);
+
+        // when - "배송" 키워드로 검색
+        ResultActions resultActions = mvc.perform(get("/api/notices")
+                        .param("keyword", "배송")
+                        .param("page", "1")
+                        .param("size", "10")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print());
+
+        // then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value("200"))
+                .andExpect(jsonPath("$.data.notices.length()").value(1))
+                .andExpect(jsonPath("$.data.notices[0].title").value("배송 관련 공지"));
+    }
+
+    @Test
+    @DisplayName("4. 공지사항 상세 조회 - 성공")
+    void t4() throws Exception {
+        // given
+        Notice notice = Notice.builder()
+                .title("테스트 공지사항")
+                .content("테스트 내용입니다.")
+                .isImportant(true)
+                .build();
+        noticeRepository.save(notice);
+
+        Long initialViewCount = notice.getViewCount();
+
+        // when
+        ResultActions resultActions = mvc.perform(get("/api/notices/" + notice.getId())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print());
+
+        // then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value("200"))
+                .andExpect(jsonPath("$.msg").value("공지사항 상세 조회 성공"))
+                .andExpect(jsonPath("$.data.id").value(notice.getId()))
+                .andExpect(jsonPath("$.data.title").value("테스트 공지사항"))
+                .andExpect(jsonPath("$.data.content").value("테스트 내용입니다."))
+                .andExpect(jsonPath("$.data.isImportant").value(true))
+                .andExpect(jsonPath("$.data.viewCount").value(initialViewCount + 1));
+    }
+
+    @Test
+    @DisplayName("5. 공지사항 상세 조회 - 실패 (존재하지 않는 공지사항)")
+    void t5() throws Exception {
+        // when
+        ResultActions resultActions = mvc.perform(get("/api/notices/99999")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print());
+
+        // then
+        resultActions.andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.resultCode").value("404"))
+                .andExpect(jsonPath("$.msg").value("존재하지 않는 공지사항입니다."));
+    }
+
+    // ========================================
+    // 관리자 전용 API 테스트
+    // ========================================
+
+    @Test
+    @WithUserDetails("admin1@admin.com")
+    @DisplayName("6. 공지사항 생성 - 성공 (관리자)")
+    void t6() throws Exception {
+        // when
+        ResultActions resultActions = mvc.perform(multipart("/api/notices")
+                        .param("title", "새로운 공지사항")
+                        .param("content", "새로운 공지사항 내용입니다.")
+                        .param("isImportant", "true")
+                        .contentType(MediaType.MULTIPART_FORM_DATA))
+                .andDo(print());
+
+        // then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value("200"))
+                .andExpect(jsonPath("$.msg").value("공지사항이 성공적으로 등록되었습니다."))
+                .andExpect(jsonPath("$.data").isNumber());
+    }
+
+    @Test
+    @DisplayName("7. 공지사항 생성 - 실패 (미인증)")
+    void t7() throws Exception {
+        // when
+        ResultActions resultActions = mvc.perform(multipart("/api/notices")
+                        .param("title", "새로운 공지사항")
+                        .param("content", "새로운 공지사항 내용입니다.")
+                        .param("isImportant", "false")
+                        .contentType(MediaType.MULTIPART_FORM_DATA))
+                .andDo(print());
+
+        // then
+        resultActions.andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithUserDetails("user1@user.com")
+    @DisplayName("8. 공지사항 생성 - 실패 (일반 사용자)")
+    void t8() throws Exception {
+        // when
+        ResultActions resultActions = mvc.perform(multipart("/api/notices")
+                        .param("title", "새로운 공지사항")
+                        .param("content", "새로운 공지사항 내용입니다.")
+                        .param("isImportant", "false")
+                        .contentType(MediaType.MULTIPART_FORM_DATA))
+                .andDo(print());
+
+        // then
+        resultActions.andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithUserDetails("admin1@admin.com")
+    @DisplayName("9. 공지사항 생성 - 실패 (필수 필드 누락)")
+    void t9() throws Exception {
+        // when - 제목 누락
+        ResultActions resultActions = mvc.perform(multipart("/api/notices")
+                        .param("content", "내용만 있습니다.")
+                        .param("isImportant", "false")
+                        .contentType(MediaType.MULTIPART_FORM_DATA))
+                .andDo(print());
+
+        // then
+        resultActions.andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithUserDetails("admin1@admin.com")
+    @DisplayName("10. 공지사항 수정 - 성공")
+    void t10() throws Exception {
+        // given
+        Notice notice = Notice.builder()
+                .title("수정 전 제목")
+                .content("수정 전 내용")
+                .isImportant(false)
+                .build();
+        noticeRepository.save(notice);
+
+        // when
+        ResultActions resultActions = mvc.perform(multipart("/api/notices/" + notice.getId())
+                        .with(request -> {
+                            request.setMethod("PUT");
+                            return request;
+                        })
+                        .param("title", "수정 후 제목")
+                        .param("content", "수정 후 내용")
+                        .param("isImportant", "true")
+                        .contentType(MediaType.MULTIPART_FORM_DATA))
+                .andDo(print());
+
+        // then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value("200"))
+                .andExpect(jsonPath("$.msg").value("공지사항이 성공적으로 수정되었습니다."));
+
+        // 실제로 수정되었는지 확인
+        Notice updatedNotice = noticeRepository.findById(notice.getId()).orElseThrow();
+        assertThat(updatedNotice.getTitle()).isEqualTo("수정 후 제목");
+        assertThat(updatedNotice.getContent()).isEqualTo("수정 후 내용");
+        assertThat(updatedNotice.getIsImportant()).isTrue();
+    }
+
+    @Test
+    @WithUserDetails("admin1@admin.com")
+    @DisplayName("11. 공지사항 수정 - 실패 (존재하지 않는 공지사항)")
+    void t11() throws Exception {
+        // when
+        ResultActions resultActions = mvc.perform(multipart("/api/notices/99999")
+                        .with(request -> {
+                            request.setMethod("PUT");
+                            return request;
+                        })
+                        .param("title", "수정 제목")
+                        .param("content", "수정 내용")
+                        .param("isImportant", "false")
+                        .contentType(MediaType.MULTIPART_FORM_DATA))
+                .andDo(print());
+
+        // then
+        resultActions.andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.resultCode").value("404"))
+                .andExpect(jsonPath("$.msg").value("존재하지 않는 공지사항입니다."));
+    }
+
+    @Test
+    @WithUserDetails("admin1@admin.com")
+    @DisplayName("12. 공지사항 삭제 - 성공")
+    void t12() throws Exception {
+        // given
+        Notice notice = Notice.builder()
+                .title("삭제할 공지사항")
+                .content("삭제할 내용")
+                .isImportant(false)
+                .build();
+        noticeRepository.save(notice);
+
+        // when
+        ResultActions resultActions = mvc.perform(delete("/api/notices/" + notice.getId())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print());
+
+        // then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value("200"))
+                .andExpect(jsonPath("$.msg").value("공지사항이 삭제되었습니다."));
+
+        // 실제로 삭제되었는지 확인
+        assertThat(noticeRepository.findById(notice.getId())).isEmpty();
+    }
+
+    @Test
+    @WithUserDetails("admin1@admin.com")
+    @DisplayName("13. 공지사항 삭제 - 실패 (존재하지 않는 공지사항)")
+    void t13() throws Exception {
+        // when
+        ResultActions resultActions = mvc.perform(delete("/api/notices/99999")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print());
+
+        // then
+        resultActions.andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.resultCode").value("404"))
+                .andExpect(jsonPath("$.msg").value("존재하지 않는 공지사항입니다."));
+    }
+
+    @Test
+    @WithUserDetails("user1@user.com")
+    @DisplayName("14. 공지사항 삭제 - 실패 (일반 사용자)")
+    void t14() throws Exception {
+        // given
+        Notice notice = Notice.builder()
+                .title("삭제할 공지사항")
+                .content("삭제할 내용")
+                .isImportant(false)
+                .build();
+        noticeRepository.save(notice);
+
+        // when
+        ResultActions resultActions = mvc.perform(delete("/api/notices/" + notice.getId())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print());
+
+        // then
+        resultActions.andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("15. 공지사항 삭제 - 실패 (미인증)")
+    void t15() throws Exception {
+        // when
+        ResultActions resultActions = mvc.perform(delete("/api/notices/1")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print());
+
+        // then
+        resultActions.andExpect(status().isUnauthorized());
+    }
+}

--- a/src/test/java/com/back/domain/notice/service/NoticeServiceTest.java
+++ b/src/test/java/com/back/domain/notice/service/NoticeServiceTest.java
@@ -1,0 +1,297 @@
+package com.back.domain.notice.service;
+
+import com.back.domain.notice.dto.request.NoticeCreateRequest;
+import com.back.domain.notice.dto.request.NoticeUpdateRequest;
+import com.back.domain.notice.dto.response.NoticeDetailResponse;
+import com.back.domain.notice.dto.response.NoticeListResponse;
+import com.back.domain.notice.entity.Notice;
+import com.back.domain.notice.repository.NoticeDocumentRepository;
+import com.back.domain.notice.repository.NoticeRepository;
+import com.back.global.exception.ServiceException;
+import com.back.global.s3.S3Service;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.verify;
+
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+@DisplayName("NoticeService 단위 테스트")
+public class NoticeServiceTest {
+
+    @Mock
+    private NoticeRepository noticeRepository;
+    @Mock
+    private NoticeDocumentRepository noticeDocumentRepository;
+    @Mock
+    private S3Service s3Service;
+
+    @InjectMocks
+    private NoticeService noticeService;
+
+    private Notice testNotice;
+    private NoticeCreateRequest validCreateRequest;
+
+    @BeforeEach
+    void setUp() {
+        // 테스트용 Notice 생성
+        testNotice = Notice.builder()
+                .title("테스트 공지사항")
+                .content("테스트 내용입니다.")
+                .isImportant(false)
+                .build();
+        ReflectionTestUtils.setField(testNotice, "id", 1L);
+
+        // 테스트용 CreateRequest 생성
+        validCreateRequest = new NoticeCreateRequest(
+                "새로운 공지사항",
+                "새로운 공지사항 내용입니다.",
+                false,
+                null
+        );
+    }
+
+    @Nested
+    @DisplayName("공지사항 생성 테스트")
+    class CreateNoticeTest {
+
+        @Test
+        @DisplayName("공지사항 생성 성공")
+        void createNotice_Success() {
+            // given
+            Notice savedNotice = Notice.builder()
+                    .title(validCreateRequest.title())
+                    .content(validCreateRequest.content())
+                    .isImportant(validCreateRequest.isImportant())
+                    .build();
+            ReflectionTestUtils.setField(savedNotice, "id", 1L);
+
+            given(noticeRepository.save(any(Notice.class))).willReturn(savedNotice);
+
+            // when
+            Long noticeId = noticeService.createNotice(validCreateRequest);
+
+            // then
+            assertThat(noticeId).isEqualTo(1L);
+            verify(noticeRepository).save(any(Notice.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("공지사항 목록 조회 테스트")
+    class GetNoticesTest {
+
+        @Test
+        @DisplayName("공지사항 목록 조회 성공")
+        void getNotices_Success() {
+            // given
+            Pageable pageable = PageRequest.of(0, 10);
+            List<Notice> notices = List.of(testNotice);
+            Page<Notice> noticePage = new PageImpl<>(notices, pageable, 1);
+
+            given(noticeRepository.findAllByOrderByIsImportantDescCreateDateDesc(pageable))
+                    .willReturn(noticePage);
+
+            // when
+            NoticeListResponse response = noticeService.getNotices(null, pageable);
+
+            // then
+            assertThat(response.notices()).hasSize(1);
+            assertThat(response.totalElements()).isEqualTo(1);
+            assertThat(response.currentPage()).isEqualTo(0);
+            verify(noticeRepository).findAllByOrderByIsImportantDescCreateDateDesc(pageable);
+        }
+
+        @Test
+        @DisplayName("공지사항 검색 성공")
+        void getNotices_SearchSuccess() {
+            // given
+            String keyword = "테스트";
+            Pageable pageable = PageRequest.of(0, 10);
+            List<Notice> notices = List.of(testNotice);
+            Page<Notice> noticePage = new PageImpl<>(notices, pageable, 1);
+
+            given(noticeRepository.searchByKeyword(keyword, pageable))
+                    .willReturn(noticePage);
+
+            // when
+            NoticeListResponse response = noticeService.getNotices(keyword, pageable);
+
+            // then
+            assertThat(response.notices()).hasSize(1);
+            verify(noticeRepository).searchByKeyword(keyword, pageable);
+        }
+
+        @Test
+        @DisplayName("공지사항 목록 조회 - 빈 목록")
+        void getNotices_EmptyList() {
+            // given
+            Pageable pageable = PageRequest.of(0, 10);
+            Page<Notice> emptyPage = new PageImpl<>(new ArrayList<>(), pageable, 0);
+
+            given(noticeRepository.findAllByOrderByIsImportantDescCreateDateDesc(pageable))
+                    .willReturn(emptyPage);
+
+            // when
+            NoticeListResponse response = noticeService.getNotices(null, pageable);
+
+            // then
+            assertThat(response.notices()).isEmpty();
+            assertThat(response.totalElements()).isEqualTo(0);
+        }
+    }
+
+    @Nested
+    @DisplayName("공지사항 상세 조회 테스트")
+    class GetNoticeTest {
+
+        @Test
+        @DisplayName("공지사항 상세 조회 성공")
+        void getNotice_Success() {
+            // given
+            given(noticeRepository.findByIdWithDocuments(1L))
+                    .willReturn(Optional.of(testNotice));
+
+            Long initialViewCount = testNotice.getViewCount();
+
+            // when
+            NoticeDetailResponse response = noticeService.getNotice(1L);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.id()).isEqualTo(1L);
+            assertThat(response.title()).isEqualTo("테스트 공지사항");
+            assertThat(response.viewCount()).isEqualTo(initialViewCount + 1);
+            verify(noticeRepository).findByIdWithDocuments(1L);
+        }
+
+        @Test
+        @DisplayName("공지사항 상세 조회 실패 - 존재하지 않는 공지사항")
+        void getNotice_NotFound() {
+            // given
+            given(noticeRepository.findByIdWithDocuments(999L))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> noticeService.getNotice(999L))
+                    .isInstanceOf(ServiceException.class)
+                    .satisfies(ex -> {
+                        ServiceException serviceEx = (ServiceException) ex;
+                        assertThat(serviceEx.getResultCode()).isEqualTo("404");
+                        assertThat(serviceEx.getMsg()).isEqualTo("존재하지 않는 공지사항입니다.");
+                    });
+        }
+    }
+
+    @Nested
+    @DisplayName("공지사항 수정 테스트")
+    class UpdateNoticeTest {
+
+        @Test
+        @DisplayName("공지사항 수정 성공")
+        void updateNotice_Success() {
+            // given
+            NoticeUpdateRequest updateRequest = new NoticeUpdateRequest(
+                    "수정된 제목",
+                    "수정된 내용",
+                    true,
+                    null,
+                    null
+            );
+
+            given(noticeRepository.findByIdWithDocuments(1L))
+                    .willReturn(Optional.of(testNotice));
+
+            // when
+            noticeService.updateNotice(1L, updateRequest);
+
+            // then
+            assertThat(testNotice.getTitle()).isEqualTo("수정된 제목");
+            assertThat(testNotice.getContent()).isEqualTo("수정된 내용");
+            assertThat(testNotice.getIsImportant()).isTrue();
+            verify(noticeRepository).findByIdWithDocuments(1L);
+        }
+
+        @Test
+        @DisplayName("공지사항 수정 실패 - 존재하지 않는 공지사항")
+        void updateNotice_NotFound() {
+            // given
+            NoticeUpdateRequest updateRequest = new NoticeUpdateRequest(
+                    "수정된 제목",
+                    "수정된 내용",
+                    false,
+                    null,
+                    null
+            );
+
+            given(noticeRepository.findByIdWithDocuments(999L))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> noticeService.updateNotice(999L, updateRequest))
+                    .isInstanceOf(ServiceException.class)
+                    .satisfies(ex -> {
+                        ServiceException serviceEx = (ServiceException) ex;
+                        assertThat(serviceEx.getResultCode()).isEqualTo("404");
+                        assertThat(serviceEx.getMsg()).isEqualTo("존재하지 않는 공지사항입니다.");
+                    });
+        }
+    }
+
+    @Nested
+    @DisplayName("공지사항 삭제 테스트")
+    class DeleteNoticeTest {
+
+        @Test
+        @DisplayName("공지사항 삭제 성공")
+        void deleteNotice_Success() {
+            // given
+            given(noticeRepository.findByIdWithDocuments(1L))
+                    .willReturn(Optional.of(testNotice));
+
+            // when
+            noticeService.deleteNotice(1L);
+
+            // then
+            verify(noticeRepository).findByIdWithDocuments(1L);
+            verify(noticeRepository).delete(testNotice);
+        }
+
+        @Test
+        @DisplayName("공지사항 삭제 실패 - 존재하지 않는 공지사항")
+        void deleteNotice_NotFound() {
+            // given
+            given(noticeRepository.findByIdWithDocuments(999L))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> noticeService.deleteNotice(999L))
+                    .isInstanceOf(ServiceException.class)
+                    .satisfies(ex -> {
+                        ServiceException serviceEx = (ServiceException) ex;
+                        assertThat(serviceEx.getResultCode()).isEqualTo("404");
+                        assertThat(serviceEx.getMsg()).isEqualTo("존재하지 않는 공지사항입니다.");
+                    });
+        }
+    }
+}


### PR DESCRIPTION
## 📢 기능 설명

공지사항 CRUD 기능 구현 했습니다.
관리자만 수정/삭제 가능

### 생성된 API 엔드포인트
- `GET /api/notices` - 공지사항 목록 조회 (전체 공개)
- `GET /api/notices/{id}` - 공지사항 상세 조회 (전체 공개)
- `POST /api/notices` - 공지사항 생성 (관리자 전용)
- `PUT /api/notices/{id}` - 공지사항 수정 (관리자 전용)
- `DELETE /api/notices/{id}` - 공지사항 삭제 (관리자 전용)

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #259 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?
