### PR TITLE
[refactor] 소셜 로그인 시, 추가 정보 확인/입력 API 구현

### DIFF
--- a/src/main/java/com/back/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/back/domain/auth/controller/AuthController.java
@@ -23,6 +23,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Slf4j
@@ -177,6 +178,22 @@ public class AuthController {
                 .body(RsData.of("200", "토큰 재발급 성공", response));
     }
 
+    /**
+     * 현재 로그인한 사용자 정보 조회
+     */
+    @GetMapping("/me")
+    @Operation(summary = "현재 사용자 정보 조회", description = "로그인한 사용자의 정보를 조회합니다. 소셜 로그인 후 추가 정보 필요 여부를 확인할 수 있습니다.")
+    public ResponseEntity<RsData<AuthResponse>> getCurrentUser(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        log.info("현재 사용자 정보 조회 - userId: {}", userDetails.getUserId());
+
+        AuthResponse response = authService.getCurrentUser(userDetails.getUserId());
+
+        return ResponseEntity.ok(
+                RsData.of("200", "사용자 정보 조회 성공", response)
+        );
+    }
 
     /**
      * 쿠키 생성 헬퍼 메서드

--- a/src/main/java/com/back/domain/auth/dto/response/AuthResponse.java
+++ b/src/main/java/com/back/domain/auth/dto/response/AuthResponse.java
@@ -16,7 +16,10 @@ public record AuthResponse(
         // 로그인 가능한 역할 목록
         List<Role> availableRoles,
 
-        Long accessTokenExpiresIn
+        Long accessTokenExpiresIn,
+
+        // 추가 정보 필요 여부 (소셜로그인 사용자)
+        boolean needsAdditionalInfo
 ) {
 
     // 로그인 성공 응답용 정적 팩토리 메서드
@@ -27,7 +30,8 @@ public record AuthResponse(
             String email,
             Role selectedRole,
             List<Role> availableRoles,
-            Long accessTokenExpiresIn
+            Long accessTokenExpiresIn,
+            boolean needsAdditionalInfo
     ) {
         return new AuthResponse(
                 accessToken,
@@ -36,7 +40,8 @@ public record AuthResponse(
                 email,
                 selectedRole,
                 availableRoles,
-                accessTokenExpiresIn
+                accessTokenExpiresIn,
+                needsAdditionalInfo
         );
     }
 
@@ -48,7 +53,8 @@ public record AuthResponse(
             String email,
             Role selectedRole,
             List<Role> availableRoles,
-            Long accessTokenExpiresIn
+            Long accessTokenExpiresIn,
+            boolean needsAdditionalInfo
     ) {
         return new AuthResponse(
                 accessToken,
@@ -57,7 +63,8 @@ public record AuthResponse(
                 email,
                 selectedRole,
                 availableRoles,
-                accessTokenExpiresIn
+                accessTokenExpiresIn,
+                needsAdditionalInfo
         );
     }
 }

--- a/src/main/java/com/back/domain/auth/repository/UserTokenRepository.java
+++ b/src/main/java/com/back/domain/auth/repository/UserTokenRepository.java
@@ -22,6 +22,9 @@ public interface UserTokenRepository extends JpaRepository<UserToken, Long> {
     @Query("DELETE FROM UserToken ut WHERE ut.user.id = :userId")
     int deleteAllRefreshTokenByUserId(@Param("userId") Long userId);
 
+    // 특정 사용자의 가장 최근 활성화된 토큰 조회
+    Optional<UserToken> findFirstByUserIdAndIsActiveTrueOrderByCreateDateDesc(Long userId);
+
     /**
      * 토큰 비활성화 메서드 -  주석 처리된 부분은 필요에 따라 활성화하여 사용
      */

--- a/src/main/java/com/back/domain/auth/service/AuthService.java
+++ b/src/main/java/com/back/domain/auth/service/AuthService.java
@@ -97,7 +97,8 @@ public class AuthService {
                 user.getEmail(),
                 request.selectedRole(),
                 user.getAvailableLoginRoles(),
-                accessTokenExpiration / 1000
+                accessTokenExpiration / 1000,
+                user.needsAdditionalInfo() // 소셜로그인 사용자 추가 정보 필요 여부
         );
     }
 
@@ -143,7 +144,8 @@ public class AuthService {
                 user.getEmail(),
                 userToken.getLoginRole(),
                 user.getAvailableLoginRoles(),
-                accessTokenExpiration / 1000
+                accessTokenExpiration / 1000,
+                user.needsAdditionalInfo() // 소셜로그인 사용자 추가 정보 필요 여부
         );
     }
 
@@ -279,5 +281,33 @@ public class AuthService {
         }
 
         return userToken;
+    }
+
+    /**
+     * 현재 로그인한 사용자 정보 조회
+     */
+    @Transactional(readOnly = true)
+    public AuthResponse getCurrentUser(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ServiceException("404", "사용자를 찾을 수 없습니다."));
+
+        // 현재 활성화된 토큰 조회 (가장 최근 토큰 하나만)
+        UserToken userToken = userTokenRepository
+                .findFirstByUserIdAndIsActiveTrueOrderByCreateDateDesc(userId)
+                .orElseThrow(() -> new ServiceException("401", "유효한 토큰이 없습니다."));
+
+        log.info("현재 사용자 정보 조회: userId={}, needsAdditionalInfo={}",
+                userId, user.needsAdditionalInfo());
+
+        return AuthResponse.loginSuccess(
+                null,  // accessToken은 이미 쿠키에 있으므로 null
+                null,  // refreshToken도 이미 쿠키에 있으므로 null
+                user.getId(),
+                user.getEmail(),
+                userToken.getLoginRole(),
+                user.getAvailableLoginRoles(),
+                accessTokenExpiration / 1000,
+                user.needsAdditionalInfo()
+        );
     }
 }

--- a/src/main/java/com/back/domain/user/controller/UserController.java
+++ b/src/main/java/com/back/domain/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.back.domain.user.controller;
 
+import com.back.domain.user.dto.request.UpdateOAuthUserInfoRequest;
 import com.back.domain.user.dto.request.UpdateUserInfoRequest;
 import com.back.domain.user.dto.response.UserProfileResponse;
 import com.back.domain.user.service.UserService;
@@ -55,6 +56,27 @@ public class UserController {
 
         return ResponseEntity.ok(
                 RsData.of("200", "사용자 정보 수정 성공", response)
+        );
+    }
+
+    /**
+     * OAuth 사용자 전화번호 입력
+     */
+    @PatchMapping("/me/oauth-info")
+    @Operation(summary = "OAuth 전화번호 입력",
+            description = "소셜 로그인 사용자가 전화번호를 입력합니다. (최초 1회)")
+    public ResponseEntity<RsData<UserProfileResponse>> updateOAuthAdditionalInfo(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody UpdateOAuthUserInfoRequest request) {
+
+        log.info("OAuth 전화번호 입력 - userId: {}, phone: {}",
+                userDetails.getUserId(), request.phone());
+
+        UserProfileResponse response = userService.updateOAuthAdditionalInfo(
+                userDetails.getUserId(), request);
+
+        return ResponseEntity.ok(
+                RsData.of("200", "전화번호 입력 완료", response)
         );
     }
 

--- a/src/main/java/com/back/domain/user/dto/request/UpdateOAuthUserInfoRequest.java
+++ b/src/main/java/com/back/domain/user/dto/request/UpdateOAuthUserInfoRequest.java
@@ -1,0 +1,12 @@
+package com.back.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record UpdateOAuthUserInfoRequest(
+        @NotBlank(message = "전화번호는 필수입니다.")
+        @Pattern(regexp = "^01[0-9]-\\d{4}-\\d{4}$",
+                message = "전화번호는 010-1234-5678 형식이어야 합니다.")
+        String phone
+) {
+}

--- a/src/main/java/com/back/domain/user/entity/User.java
+++ b/src/main/java/com/back/domain/user/entity/User.java
@@ -321,4 +321,11 @@ public class User extends BaseEntity {
         }
     }
 
+    /**
+     * OAuth 사용자의 추가 정보 입력 필요 여부 확인
+     */
+    public boolean needsAdditionalInfo() {
+        return isOAuthUser() && (this.phone == null || this.phone.isBlank());
+    }
+
 }

--- a/src/main/java/com/back/domain/user/service/UserService.java
+++ b/src/main/java/com/back/domain/user/service/UserService.java
@@ -1,5 +1,6 @@
 package com.back.domain.user.service;
 
+import com.back.domain.user.dto.request.UpdateOAuthUserInfoRequest;
 import com.back.domain.user.dto.request.UpdateUserInfoRequest;
 import com.back.domain.user.dto.response.UserProfileResponse;
 import com.back.domain.user.entity.Grade;
@@ -99,6 +100,41 @@ public class UserService {
         }
 
         log.info("사용자 정보 수정 완료 - userId: {}, nickname: {}", userId, request.name());
+
+        return UserProfileResponse.from(user);
+    }
+
+    /**
+     * OAuth 사용자 추가 정보 입력 (전화번호)
+     */
+    @Transactional
+    public UserProfileResponse updateOAuthAdditionalInfo(Long userId, UpdateOAuthUserInfoRequest request) {
+        User user = getUserById(userId);
+
+        // 1. OAuth 사용자만 가능
+        if (!user.isOAuthUser()) {
+            throw new ServiceException("400", "소셜 로그인 사용자만 이용할 수 있습니다.");
+        }
+
+        // 2. 이미 전화번호가 있으면 수정 불가 (최초 1회만)
+        if (user.getPhone() != null && !user.getPhone().isBlank()) {
+            throw new ServiceException("400", "이미 전화번호를 등록하셨습니다.");
+        }
+
+        // 3. 전화번호 중복 체크
+        if (userRepository.existsByPhone(request.phone())) {
+            throw new ServiceException("409", "이미 사용 중인 전화번호입니다.");
+        }
+
+        // 4. 전화번호 업데이트
+        user.updateProfile(
+                null,              // name 변경 안 함
+                request.phone(),   // phone만 업데이트
+                null, null, null,  // 주소 변경 안 함
+                null               // 프로필 이미지 변경 안 함
+        );
+
+        log.info("OAuth 전화번호 입력 완료 - userId: {}, phone: {}", userId, request.phone());
 
         return UserProfileResponse.from(user);
     }

--- a/src/main/java/com/back/global/initData/TestInitData.java
+++ b/src/main/java/com/back/global/initData/TestInitData.java
@@ -10,6 +10,7 @@ import com.back.domain.product.category.entity.Category;
 import com.back.domain.product.category.repository.CategoryRepository;
 import com.back.domain.product.tag.entity.Tag;
 import com.back.domain.product.tag.repository.TagRepository;
+import com.back.domain.user.entity.Provider;
 import com.back.domain.user.entity.Role;
 import com.back.domain.user.entity.User;
 import com.back.domain.user.repository.UserRepository;
@@ -64,6 +65,7 @@ public class TestInitData {
 
         createUser("artist1@artist.com", "1234qwer!", "작가1", "010-2111-1111", Role.ARTIST);
         createUser("admin1@admin.com", "1234qwer!", "관리자1", "010-3111-1111", Role.ADMIN);
+        createOAuthUser("oauth@user.com", "OAuth테스트유저", Provider.GOOGLE, "google-test-id-123");
     }
 
     private void safeSignup(String email, String password, String passwordConfirm, String name, String phone) {
@@ -264,5 +266,17 @@ public class TestInitData {
                     log.info("하위 카테고리 생성: {} (부모: {})", categoryName, parent.getCategoryName());
                     return saved;
                 });
+    }
+
+    // OAuth 테스트 사용자 생성
+    private void createOAuthUser(String email, String name, Provider provider, String providerId) {
+        if (userRepository.existsByEmail(email)) {
+            log.debug("OAuth 사용자 이미 존재: {}", email);
+            return;
+        }
+
+        User oauthUser = User.createOAuthUser(email, name, provider, providerId);
+        userRepository.save(oauthUser);
+        log.info("OAuth 테스트 사용자 생성: email={}, provider={}", email, provider);
     }
 }

--- a/src/test/java/com/back/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/back/domain/auth/controller/AuthControllerTest.java
@@ -180,7 +180,7 @@ class AuthControllerTest {
 
             AuthResponse mockResponse = new AuthResponse(
                     "accessToken", "refreshToken", 1L, "test@example.com",
-                    Role.USER, List.of(Role.USER), 1800L
+                    Role.USER, List.of(Role.USER), 1800L, false
             );
 
             given(authService.login(any(LoginRequest.class))).willReturn(mockResponse);
@@ -211,7 +211,7 @@ class AuthControllerTest {
 
             AuthResponse mockResponse = new AuthResponse(
                     "accessToken", "refreshToken", 1L, "test@example.com",
-                    Role.USER, List.of(Role.USER), 1800L
+                    Role.USER, List.of(Role.USER), 1800L, false
             );
 
             given(authService.login(any(LoginRequest.class))).willReturn(mockResponse);
@@ -242,7 +242,7 @@ class AuthControllerTest {
 
                 AuthResponse mockResponse = new AuthResponse(
                         "accessToken", "refreshToken", 1L, "test@example.com",
-                        role, List.of(role), 1800L
+                        role, List.of(role), 1800L, false
                 );
 
                 given(authService.login(any(LoginRequest.class))).willReturn(mockResponse);
@@ -273,7 +273,7 @@ class AuthControllerTest {
 
             AuthResponse mockResponse = new AuthResponse(
                     "accessToken123", "refreshToken456", 1L, "test@example.com",
-                    Role.USER, List.of(Role.USER), 1800L
+                    Role.USER, List.of(Role.USER), 1800L, false
             );
 
             given(authService.login(any(LoginRequest.class))).willReturn(mockResponse);
@@ -299,7 +299,7 @@ class AuthControllerTest {
 
             AuthResponse mockResponse = new AuthResponse(
                     "accessToken", "refreshToken", 1L, "admin@example.com",
-                    Role.ADMIN, List.of(Role.USER, Role.ARTIST, Role.ADMIN), 1800L
+                    Role.ADMIN, List.of(Role.USER, Role.ARTIST, Role.ADMIN), 1800L, false
             );
 
             given(authService.login(any(LoginRequest.class))).willReturn(mockResponse);
@@ -326,7 +326,7 @@ class AuthControllerTest {
             Long expectedExpiration = 3600L; // 1시간
             AuthResponse mockResponse = new AuthResponse(
                     "accessToken", "refreshToken", 1L, "test@example.com",
-                    Role.USER, List.of(Role.USER), expectedExpiration
+                    Role.USER, List.of(Role.USER), expectedExpiration, false
             );
 
             given(authService.login(any(LoginRequest.class))).willReturn(mockResponse);
@@ -689,7 +689,7 @@ class AuthControllerTest {
 
             AuthResponse mockResponse = new AuthResponse(
                     "newAccessToken", "newRefreshToken", 1L, "test@example.com",
-                    Role.USER, List.of(Role.USER), 1800L
+                    Role.USER, List.of(Role.USER), 1800L, false
             );
             given(authService.refreshToken(request)).willReturn(mockResponse);
 
@@ -721,7 +721,7 @@ class AuthControllerTest {
                 TokenRefreshRequest request = new TokenRefreshRequest(tokens[i]);
                 AuthResponse mockResponse = new AuthResponse(
                         "accessToken" + i, "refreshToken" + i, (long) (i + 1),
-                        "user" + i + "@example.com", Role.USER, List.of(Role.USER), 1800L
+                        "user" + i + "@example.com", Role.USER, List.of(Role.USER), 1800L, false
                 );
                 given(authService.refreshToken(request)).willReturn(mockResponse);
 
@@ -745,7 +745,7 @@ class AuthControllerTest {
             TokenRefreshRequest request = new TokenRefreshRequest("validRefreshToken");
             AuthResponse mockResponse = new AuthResponse(
                     "newAccessToken123", "newRefreshToken456", 1L, "test@example.com",
-                    Role.USER, List.of(Role.USER), 1800L
+                    Role.USER, List.of(Role.USER), 1800L, false
             );
             given(authService.refreshToken(request)).willReturn(mockResponse);
 
@@ -765,7 +765,7 @@ class AuthControllerTest {
             TokenRefreshRequest request = new TokenRefreshRequest("refreshTokenWithRoleChange");
             AuthResponse mockResponse = new AuthResponse(
                     "newAccessToken", "newRefreshToken", 1L, "admin@example.com",
-                    Role.ADMIN, List.of(Role.USER, Role.ADMIN), 1800L
+                    Role.ADMIN, List.of(Role.USER, Role.ADMIN), 1800L, false
             );
             given(authService.refreshToken(request)).willReturn(mockResponse);
 
@@ -786,7 +786,7 @@ class AuthControllerTest {
             Long newExpirationTime = 3600L; // 1시간
             AuthResponse mockResponse = new AuthResponse(
                     "newAccessToken", "newRefreshToken", 1L, "test@example.com",
-                    Role.USER, List.of(Role.USER), newExpirationTime
+                    Role.USER, List.of(Role.USER), newExpirationTime, false
             );
             given(authService.refreshToken(request)).willReturn(mockResponse);
 
@@ -805,11 +805,11 @@ class AuthControllerTest {
             TokenRefreshRequest request = new TokenRefreshRequest("sameRefreshToken");
             AuthResponse mockResponse1 = new AuthResponse(
                     "accessToken1", "refreshToken1", 1L, "test@example.com",
-                    Role.USER, List.of(Role.USER), 1800L
+                    Role.USER, List.of(Role.USER), 1800L, false
             );
             AuthResponse mockResponse2 = new AuthResponse(
                     "accessToken2", "refreshToken2", 1L, "test@example.com",
-                    Role.USER, List.of(Role.USER), 1800L
+                    Role.USER, List.of(Role.USER), 1800L, false
             );
             given(authService.refreshToken(request))
                     .willReturn(mockResponse1)
@@ -832,7 +832,7 @@ class AuthControllerTest {
             TokenRefreshRequest request = new TokenRefreshRequest("userTokenToRefresh");
             AuthResponse mockResponse = new AuthResponse(
                     "newAccessToken", "newRefreshToken", 42L, "consistent@example.com",
-                    Role.ARTIST, List.of(Role.USER, Role.ARTIST), 1800L
+                    Role.ARTIST, List.of(Role.USER, Role.ARTIST), 1800L, false
             );
             given(authService.refreshToken(request)).willReturn(mockResponse);
 

--- a/src/test/java/com/back/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/back/domain/user/controller/UserControllerTest.java
@@ -18,7 +18,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ActiveProfiles("test")
 @SpringBootTest
@@ -333,4 +334,132 @@ public class UserControllerTest {
         resultActions.andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.msg").exists());
     }
+
+    @Test
+    @WithUserDetails("oauth@user.com")  // OAuth 사용자로 테스트 (전화번호 없음)
+    @DisplayName("16. OAuth 전화번호 입력 - 성공")
+    void t16() throws Exception {
+        // when
+        ResultActions resultActions = mvc.perform(patch("/api/users/me/oauth-info")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                            {
+                              "phone": "010-5432-1878"
+                            }
+                            """))
+                .andDo(print());
+
+        // then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value("200"))
+                .andExpect(jsonPath("$.msg").value("전화번호 입력 완료"))
+                .andExpect(jsonPath("$.data.phone").value("010-5432-1878"));
+    }
+
+    @Test
+    @WithUserDetails("oauth@user.com")
+    @DisplayName("17. OAuth 전화번호 입력 - 실패 (이미 등록됨)")
+    void t17() throws Exception {
+        // given - 먼저 전화번호 입력
+        mvc.perform(patch("/api/users/me/oauth-info")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "phone": "010-1111-2222"
+                    }
+                    """));
+
+        // when - 다시 입력 시도
+        ResultActions resultActions = mvc.perform(patch("/api/users/me/oauth-info")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                            {
+                              "phone": "010-3333-4444"
+                            }
+                            """))
+                .andDo(print());
+
+        // then
+        resultActions.andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.msg").value("이미 전화번호를 등록하셨습니다."));
+    }
+
+    @Test
+    @WithUserDetails("user1@user.com")  // 일반 로컬 사용자
+    @DisplayName("18. OAuth 전화번호 입력 - 실패 (OAuth 사용자 아님)")
+    void t18() throws Exception {
+        // when
+        ResultActions resultActions = mvc.perform(patch("/api/users/me/oauth-info")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                            {
+                              "phone": "010-5555-6666"
+                            }
+                            """))
+                .andDo(print());
+
+        // then
+        resultActions.andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.msg").value("소셜 로그인 사용자만 이용할 수 있습니다."));
+    }
+
+    @Test
+    @WithUserDetails("oauth@user.com")
+    @DisplayName("19. OAuth 전화번호 입력 - 실패 (전화번호 형식 오류)")
+    void t19() throws Exception {
+        // when
+        ResultActions resultActions = mvc.perform(patch("/api/users/me/oauth-info")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                            {
+                              "phone": "01012345678"
+                            }
+                            """))
+                .andDo(print());
+
+        // then
+        resultActions.andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.msg").value("phone: 전화번호는 010-1234-5678 형식이어야 합니다."));
+    }
+
+    @Test
+    @WithUserDetails("oauth@user.com")
+    @DisplayName("20. OAuth 전화번호 입력 - 실패 (전화번호 중복)")
+    void t20() throws Exception {
+        // given - 다른 사용자의 전화번호
+        User existingUser = userRepository.findByEmail("user1@user.com").orElseThrow();
+        String existingPhone = existingUser.getPhone();
+
+        // when
+        ResultActions resultActions = mvc.perform(patch("/api/users/me/oauth-info")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                            {
+                              "phone": "%s"
+                            }
+                            """.formatted(existingPhone)))
+                .andDo(print());
+
+        // then
+        resultActions.andExpect(status().isConflict())
+                .andExpect(jsonPath("$.msg").value("이미 사용 중인 전화번호입니다."));
+    }
+
+    @Test
+    @DisplayName("21. OAuth 전화번호 입력 - 실패 (미인증)")
+    void t21() throws Exception {
+        // when
+        ResultActions resultActions = mvc.perform(patch("/api/users/me/oauth-info")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                            {
+                              "phone": "010-7777-8888"
+                            }
+                            """))
+                .andDo(print());
+
+        // then
+        resultActions.andExpect(status().isUnauthorized());
+    }
+
 }


### PR DESCRIPTION
## 📢 기능 설명

소셜 로그인 시, 추가정보를 입력받기 위한 API 구현

### 흐름도 
소셜 로그인 완료 → 프론트엔드 리다이렉트
  ↓
1. GET /api/auth/me
   응답: { needsAdditionalInfo: true }
  ↓
2. GET /api/users/me
   응답: { email: "user@gmail.com", name: "홍길동_GOOGLE", phone: null }
  ↓
3. 모달에 기존 정보 표시 (이메일, 닉네임 disabled)
   사용자가 전화번호 입력
  ↓
4. PATCH /api/users/me/oauth-info
   요청: { phone: "010-1234-5678" }
  ↓
5. 성공 → 메인 페이지 이동


## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #271 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?
