### PR TITLE
[feat] Spring Email 설정 및 테스트

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -70,6 +70,8 @@ dependencies {
     //Elasticsearch
     implementation ("org.springframework.boot:spring-boot-starter-data-elasticsearch")
 
+    // 이메일 발송
+    implementation("org.springframework.boot:spring-boot-starter-mail")
 }
 
 tasks.withType<Test> {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -82,6 +82,23 @@ spring:
             token-uri: https://nid.naver.com/oauth2.0/token
             user-info-uri: https://openapi.naver.com/v1/nid/me
             user-name-attribute: response
+  # Gmail SMTP 설정
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+            required: true
+          connectiontimeout: 5000
+          timeout: 5000
+          writetimeout: 5000
+    default-encoding: UTF-8
 
 # Frontend URL (OAuth2 리다이렉트용, UTM 링크 생성용)
 app:

--- a/src/test/java/com/back/global/email/EmailServiceTest.java
+++ b/src/test/java/com/back/global/email/EmailServiceTest.java
@@ -1,0 +1,26 @@
+package com.back.global.email;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mail.javamail.JavaMailSender;
+
+@SpringBootTest
+class EmailServiceTest {
+
+    @Autowired
+    private JavaMailSender mailSender;
+
+    // 동작 확인했습니다 - 테스트 시, 실제로 이메일이 발송되니 주석 처리 해두었습니다.
+    /*
+    @Test
+    void testEmailConnection() {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo("ahdeka01@gmail.com"); // 받는 사람 이메일 주소
+        message.setSubject("테스트 메일");
+        message.setText("설정 테스트입니다.");
+
+        mailSender.send(message);
+        System.out.println("이메일 발송 성공!");
+    }
+    */
+}


### PR DESCRIPTION
## 📢 기능 설명

- Spring Email 의존성 추가
- 모리모리 프로젝트용 Gmail 생성 후 연동

- .env 파일에 아래 내용 추가
#Gmail 설정 (이메일 발송용)
MAIL_USERNAME=morimori.store2@gmail.com
MAIL_PASSWORD=klxc voct bqcr mabh

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #308 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?
