### PR TITLE
[fix] 작가 목록 조회 ID값 불일치 오류 해결

### DIFF
--- a/src/main/java/com/back/domain/artist/dto/response/ArtistListResponse.java
+++ b/src/main/java/com/back/domain/artist/dto/response/ArtistListResponse.java
@@ -16,7 +16,7 @@ public record ArtistListResponse (
 ) {
         public static ArtistListResponse from(ArtistProfile artistProfile) {
             return new ArtistListResponse(
-                    artistProfile.getUser().getId(),
+                    artistProfile.getId(),
                     artistProfile.getArtistName()
             );
         }


### PR DESCRIPTION
## 📢 기능 설명

작가 상세보기, 팔로우 등 모두 ArtistId를 사용중이었는데

작가 목록 조회 시 Front에 넘기는 Id값이 해당 작가의 UserId값을 넘겨주고 있었음 <- 버그

수정했습니다

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #380 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?
