### PR TITLE
[fix] 작가 공개 프로필 상세조회 ID 불일치 오류 해결

### DIFF
--- a/src/main/java/com/back/domain/artist/dto/response/ArtistPublicProfileResponse.java
+++ b/src/main/java/com/back/domain/artist/dto/response/ArtistPublicProfileResponse.java
@@ -41,7 +41,7 @@ public record ArtistPublicProfileResponse(
 ) {
     public static ArtistPublicProfileResponse from(ArtistProfile artistProfile) {
         return new ArtistPublicProfileResponse(
-                artistProfile.getUser().getId(),
+                artistProfile.getId(),
                 artistProfile.getArtistName(),
                 artistProfile.getProfileImageUrl(),
                 artistProfile.getDescription(),

--- a/src/main/java/com/back/domain/artist/service/ArtistPublicService.java
+++ b/src/main/java/com/back/domain/artist/service/ArtistPublicService.java
@@ -53,7 +53,7 @@ public class ArtistPublicService {
         log.info("작가 공개 프로필 조회 시작 - artistId: {}", artistId);
 
         // 작가 프로필 조회
-        ArtistProfile artistProfile = artistProfileRepository.findByUserId(artistId)
+        ArtistProfile artistProfile = artistProfileRepository.findById(artistId)
                 .orElseThrow(() -> new ServiceException("404", "존재하지 않는 작가입니다."));
 
         log.info("작가 공개 프로필 조회 완료 - artistId: {}, artistName: {}",

--- a/src/test/java/com/back/domain/artist/controller/ArtistControllerTest.java
+++ b/src/test/java/com/back/domain/artist/controller/ArtistControllerTest.java
@@ -584,7 +584,7 @@ class ArtistControllerTest {
         artistProfileRepository.save(profile);
 
         // when
-        ResultActions resultActions = mvc.perform(get("/api/artist/profile/" + user1.getId())
+        ResultActions resultActions = mvc.perform(get("/api/artist/profile/" + profile.getId())
                         .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print());
 
@@ -592,7 +592,7 @@ class ArtistControllerTest {
         resultActions.andExpect(status().isOk())
                 .andExpect(jsonPath("$.resultCode").value("200"))
                 .andExpect(jsonPath("$.msg").value("작가 프로필 조회 성공"))
-                .andExpect(jsonPath("$.data.artistId").value(user1.getId()))
+                .andExpect(jsonPath("$.data.artistId").value(profile.getId()))
                 .andExpect(jsonPath("$.data.artistName").value("유저1작가"))
                 .andExpect(jsonPath("$.data.description").value("전통 도자기를 현대적으로 재해석하는 작가입니다."))
                 .andExpect(jsonPath("$.data.mainProducts").value("도자기, 머그컵"))


### PR DESCRIPTION
## 📢 기능 설명

작가 상세조회 시
ArtistProfile ID값을 보내야하는데 User ID값을 보내고있었음 <- 버그

수정했습니다

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #385 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?
